### PR TITLE
[Feat] 검색기능 구현 (사용자 검색만)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-easy-crop": "^5.5.6",
         "react-intersection-observer": "^10.0.0",
         "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -11493,6 +11494,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-easy-crop": "^5.5.6",
     "react-intersection-observer": "^10.0.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/components/search/SearchTabs.tsx
+++ b/src/app/components/search/SearchTabs.tsx
@@ -1,0 +1,37 @@
+// app/search/components/SearchTabs.tsx
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const tabs = [
+  { key: 'shortlog', label: '숏로그' },
+  { key: 'blog', label: '블로그' },
+  { key: 'user', label: '사용자' },
+];
+
+export default function SearchTabs({ keyword, activeTab }: { keyword: string; activeTab: string }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const sort = params.get('sort') || 'latest';
+
+  const changeTab = (tab: string) => {
+    router.push(`/search?keyword=${keyword}&tab=${tab}&sort=${sort}`);
+  };
+
+  return (
+    <div className="flex items-center gap-6 border-b border-gray-200 pb-2">
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          className={`
+            px-2 pb-1 text-lg 
+            ${activeTab === t.key ? 'border-b-2 border-black font-semibold' : 'text-gray-500'}
+          `}
+          onClick={() => changeTab(t.key)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/components/search/SortFilter.tsx
+++ b/src/app/components/search/SortFilter.tsx
@@ -1,0 +1,43 @@
+// app/search/components/SortFilter.tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+const filters = [
+  { key: 'latest', label: '최신' },
+  { key: 'popular', label: '인기' },
+  { key: 'view', label: '조회수' },
+];
+
+export default function SortFilter({
+  keyword,
+  currentTab,
+  currentSort,
+}: {
+  keyword: string;
+  currentTab: string;
+  currentSort: string;
+}) {
+  const router = useRouter();
+
+  const changeSort = (sort: string) => {
+    router.push(`/search?keyword=${keyword}&tab=${currentTab}&sort=${sort}`);
+  };
+
+  return (
+    <div className="flex gap-2 mt-4">
+      {filters.map((f) => (
+        <button
+          key={f.key}
+          onClick={() => changeSort(f.key)}
+          className={`
+            px-3 py-1 text-sm rounded-full border
+            ${currentSort === f.key ? 'bg-black text-white' : 'bg-gray-100 text-gray-600'}
+          `}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/components/sidebar/ConfirmLogoutModal.tsx
+++ b/src/app/components/sidebar/ConfirmLogoutModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type ConfirmLogoutModalProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmLogoutModal({ onConfirm, onCancel }: ConfirmLogoutModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className="
+        fixed inset-0 bg-black/40
+        flex items-center justify-center
+      "
+      style={{ zIndex: 9999999 }}
+    >
+      <div
+        className="
+          bg-white rounded-xl p-6 w-[380px] shadow-xl relative
+        "
+        style={{ zIndex: 10000000 }}
+      >
+        <h2 className="text-xl font-semibold text-center mb-6">로그아웃하시겠습니까?</h2>
+
+        <div className="flex gap-3">
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              console.log('취소 버튼 클릭됨');
+              onCancel();
+            }}
+            className="flex-1 py-3 rounded-xl border border-gray-300 hover:bg-gray-100"
+          >
+            취소
+          </button>
+
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              console.log('🔥 로그아웃 버튼 클릭됨');
+              onConfirm();
+            }}
+            className="flex-1 py-3 rounded-xl border border-red-500 text-red-500 hover:bg-red-50"
+          >
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/app/components/sidebar/MorePanel.tsx
+++ b/src/app/components/sidebar/MorePanel.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useAuth } from '@/src/providers/AuthProvider';
+import { X } from 'lucide-react';
+
+// ⭐ 추가: 모달 import
+import ConfirmLogoutModal from './ConfirmLogoutModal';
+
+export default function MorePanel({
+  onClose,
+  showLogoutModal,
+  setShowLogoutModal,
+}: {
+  onClose: () => void;
+  showLogoutModal: boolean;
+  setShowLogoutModal: (value: boolean) => void;
+}) {
+  const { logout } = useAuth();
+
+  const handleLogout = async () => {
+    console.log('로그아웃 처리');
+    await logout();
+    setShowLogoutModal(false); // 모달 닫기
+    onClose(); // 패널 닫기 (사이드바 복귀는 Sidebar가 처리)
+  };
+
+  return (
+    <>
+      <div
+        className="
+          fixed left-20 top-0 
+          w-80 h-screen 
+          bg-white border-r border-gray-200 
+          shadow-md 
+          animate-slideIn 
+          z-50
+        "
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 h-16">
+          <h2 className="text-xl font-semibold">더보기</h2>
+          <button onClick={onClose} className="p-2 rounded-full hover:bg-gray-100">
+            <X size={22} />
+          </button>
+        </div>
+
+        {/* List */}
+        <div className="p-3 space-y-1 text-[15px]">
+          <button
+            className="
+              w-full text-left font-semibold 
+              py-2 px-2 rounded-lg 
+              hover:bg-gray-100 transition
+            "
+          >
+            설정 및 개인정보
+          </button>
+          <button
+            className="
+              w-full text-left font-semibold 
+              py-2 px-2 rounded-lg 
+              hover:bg-gray-100 transition
+            "
+          >
+            다크모드 (개발중)
+          </button>
+
+          {/* ⭐ 로그아웃 메뉴 → 모달 오픈 */}
+          <button
+            onClick={() => {
+              console.log('로그아웃 모달 열기');
+              setShowLogoutModal(true);
+            }}
+            className="
+              w-full text-left font-semibold 
+              py-2 px-2 rounded-lg 
+              hover:bg-gray-100 transition
+            "
+          >
+            로그아웃
+          </button>
+        </div>
+      </div>
+
+      {showLogoutModal && (
+        <ConfirmLogoutModal onConfirm={handleLogout} onCancel={() => setShowLogoutModal(false)} />
+      )}
+    </>
+  );
+}

--- a/src/app/components/sidebar/MorePanel.tsx
+++ b/src/app/components/sidebar/MorePanel.tsx
@@ -37,7 +37,7 @@ export default function MorePanel({
         "
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 h-16">
+        <div className="flex items-center justify-between px-6 py-10 h-16">
           <h2 className="text-xl font-semibold">더보기</h2>
           <button onClick={onClose} className="p-2 rounded-full hover:bg-gray-100">
             <X size={22} />

--- a/src/app/components/sidebar/MorePanel.tsx
+++ b/src/app/components/sidebar/MorePanel.tsx
@@ -15,7 +15,7 @@ export default function MorePanel({
   showLogoutModal: boolean;
   setShowLogoutModal: (value: boolean) => void;
 }) {
-  const { logout } = useAuth();
+  const { isLogin, logout } = useAuth();
 
   const handleLogout = async () => {
     console.log('로그아웃 처리');
@@ -66,19 +66,21 @@ export default function MorePanel({
           </button>
 
           {/* ⭐ 로그아웃 메뉴 → 모달 오픈 */}
-          <button
-            onClick={() => {
-              console.log('로그아웃 모달 열기');
-              setShowLogoutModal(true);
-            }}
-            className="
-              w-full text-left font-semibold 
-              py-2 px-2 rounded-lg 
-              hover:bg-gray-100 transition
-            "
-          >
-            로그아웃
-          </button>
+          {isLogin && (
+            <button
+              onClick={() => {
+                console.log('로그아웃 모달 열기');
+                setShowLogoutModal(true);
+              }}
+              className="
+                w-full text-left font-semibold 
+                py-2 px-2 rounded-lg 
+                hover:bg-gray-100 transition
+              "
+            >
+              로그아웃
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/app/components/sidebar/SearchPanel.tsx
+++ b/src/app/components/sidebar/SearchPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAuth } from '@/src/providers/AuthProvider';
-import { ArrowLeft, Search, X } from 'lucide-react';
+import { Clock, Search, X } from 'lucide-react';
 import { useState } from 'react';
 
 export default function SearchPanel({ onClose }: { onClose: () => void }) {
@@ -39,54 +39,52 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
   const showAutoResults = keyword.length > 0;
 
   return (
-    <>
+    <div>
       {/* ====== 패널 영역 ====== */}
       <div
         className="
           fixed left-20 top-0 
           w-80 h-screen 
           bg-white border-r border-gray-200 
-          shadow-md z-50 animate-slideIn
+          shadow-md 
+          animate-slideIn 
+          z-50
         "
       >
         {/* Header */}
-        <div className="flex items-center gap-3 px-4 h-16 border-b border-gray-200">
-          <button className="p-2 rounded-full hover:bg-gray-100" onClick={onClose}>
-            <ArrowLeft size={22} />
+        <div className="flex items-center justify-between px-6 py-10 h-16">
+          <h2 className="text-xl font-semibold">검색</h2>
+          <button onClick={onClose} className="p-2 rounded-full hover:bg-gray-100">
+            <X size={22} />
           </button>
+        </div>
 
-          <div className="flex-1 relative">
-            <input
-              type="text"
-              autoFocus
-              placeholder="검색어를 입력하세요"
-              value={keyword}
-              onChange={(e) => setKeyword(e.target.value)}
-              className="
-                w-full h-12 bg-gray-100 rounded-full pl-10 pr-10
+        <div className="flex-1 relative px-4 py-2">
+          <input
+            type="text"
+            autoFocus
+            placeholder="검색어를 입력하세요"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="
+                w-full h-10 bg-gray-100 rounded-full pl-4 pr-10
                 text-[15px] outline-none border border-gray-200
                 focus:bg-white focus:ring-2 focus:ring-blue-100 transition
               "
-            />
+          />
 
-            <Search size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
-
-            {keyword && (
-              <button
-                onClick={() => setKeyword('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:bg-gray-200 rounded-full"
-              >
-                <X size={18} />
-              </button>
-            )}
-          </div>
+          {keyword && (
+            <button
+              onClick={() => setKeyword('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:bg-gray-200 rounded-full"
+            ></button>
+          )}
         </div>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
           {showAutoResults && (
             <div>
-              <h3 className="text-sm text-gray-500 mb-2">검색 결과</h3>
               <ul className="space-y-2">
                 {autoList.map((item) => (
                   <li
@@ -109,9 +107,15 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
                   {recentKeywords.map((item) => (
                     <li
                       key={item}
-                      className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
+                      className="flex items-center gap-2 px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
                     >
-                      • {item}
+                      <div className="w-4 h-4 flex items-center justify-center">
+                        <Clock size={12} className="text-gray-600" />
+                      </div>
+                      {item}
+                      <div className="ml-auto p-1">
+                        <X size={12} className="text-gray-600 hover:bg-gray-200 rounded-full" />
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -147,6 +151,6 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
           )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/components/sidebar/SearchPanel.tsx
+++ b/src/app/components/sidebar/SearchPanel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useAuth } from '@/src/providers/AuthProvider';
+import { ArrowLeft, Search, X } from 'lucide-react';
+import { useState } from 'react';
+
+export default function SearchPanel({ onClose }: { onClose: () => void }) {
+  const { isLogin } = useAuth();
+
+  const [keyword, setKeyword] = useState('');
+
+  const recommendedKeywords = [
+    '생활형 베스트',
+    '서울 숨은 맛집',
+    'Spring Boot',
+    '한국 뉴스',
+    'BlackPink',
+    '생성형 AI',
+    '낭동 찾기',
+    '일상 공유',
+  ];
+
+  const recentKeywords = isLogin
+    ? ['생물학 테스트', '서울 숨은 맛집', 'Spring Boot', '한국 뉴스']
+    : [];
+
+  const autoList = keyword
+    ? [
+        `${keyword} 강의`,
+        `${keyword} console`,
+        `${keyword} 추천`,
+        `${keyword} ec2`,
+        `${keyword} s3`,
+      ]
+    : [];
+
+  const showRecommendedOnly = !keyword && !isLogin;
+  const showRecentAndRecommend = !keyword && isLogin;
+  const showAutoResults = keyword.length > 0;
+
+  return (
+    <>
+      {/* ====== 패널 영역 ====== */}
+      <div
+        className="
+          fixed left-20 top-0 
+          w-80 h-screen 
+          bg-white border-r border-gray-200 
+          shadow-md z-50 animate-slideIn
+        "
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 h-16 border-b border-gray-200">
+          <button className="p-2 rounded-full hover:bg-gray-100" onClick={onClose}>
+            <ArrowLeft size={22} />
+          </button>
+
+          <div className="flex-1 relative">
+            <input
+              type="text"
+              autoFocus
+              placeholder="검색어를 입력하세요"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              className="
+                w-full h-12 bg-gray-100 rounded-full pl-10 pr-10
+                text-[15px] outline-none border border-gray-200
+                focus:bg-white focus:ring-2 focus:ring-blue-100 transition
+              "
+            />
+
+            <Search size={20} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+
+            {keyword && (
+              <button
+                onClick={() => setKeyword('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:bg-gray-200 rounded-full"
+              >
+                <X size={18} />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+          {showAutoResults && (
+            <div>
+              <h3 className="text-sm text-gray-500 mb-2">검색 결과</h3>
+              <ul className="space-y-2">
+                {autoList.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-center gap-2 px-2 py-2 rounded-lg hover:bg-gray-100 cursor-pointer"
+                  >
+                    <Search size={18} className="text-gray-500" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {showRecentAndRecommend && (
+            <>
+              <div>
+                <h3 className="text-sm text-gray-500 mb-2">최근 검색어</h3>
+                <ul className="space-y-1">
+                  {recentKeywords.map((item) => (
+                    <li
+                      key={item}
+                      className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
+                    >
+                      • {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm text-gray-500 mb-2">추천 검색어</h3>
+                <ul className="space-y-1">
+                  {recommendedKeywords.map((item) => (
+                    <li
+                      key={item}
+                      className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
+                    >
+                      • {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          )}
+
+          {showRecommendedOnly && (
+            <div>
+              <h3 className="text-sm text-gray-500 mb-2">추천 검색어</h3>
+              <ul className="space-y-1">
+                {recommendedKeywords.map((item) => (
+                  <li key={item} className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer">
+                    • {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -6,17 +6,20 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import MorePanel from './MorePanel';
+import SearchPanel from './SearchPanel';
 import { guestMenu, loggedInMenu } from './SideBarMenu';
 
 export default function Sidebar() {
   const { loginUser, isLogin, logout } = useAuth();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
 
   const pathname = usePathname();
   const router = useRouter();
   const moreModalRef = useRef<HTMLDivElement>(null);
+  const searchPanelRef = useRef<HTMLDivElement>(null);
 
   const menu = isLogin ? loggedInMenu : guestMenu;
 
@@ -38,12 +41,17 @@ export default function Sidebar() {
   // 외부 클릭 시 popover 닫기
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      // 로그아웃 모달이 열려있으면 외부 클릭 무시
       if (showLogoutModal) return;
+
+      if (searchPanelRef.current && !searchPanelRef.current.contains(e.target as Node)) {
+        setIsSearchOpen(false);
+        if (window.innerWidth >= 1280) {
+          setIsCollapsed(false);
+        }
+      }
 
       if (moreModalRef.current && !moreModalRef.current.contains(e.target as Node)) {
         setIsMoreOpen(false);
-        // 패널이 닫힐 때 화면이 크면 확대모드로 전환
         if (window.innerWidth >= 1280) {
           setIsCollapsed(false);
         }
@@ -83,11 +91,23 @@ export default function Sidebar() {
       {/* ======================= SEARCH AREA ======================= */}
       <div className="px-4 py-3 flex justify-start">
         <div
-          onClick={() => setIsCollapsed(!isCollapsed)}
+          onClick={() => {
+            if (isSearchOpen) {
+              setIsSearchOpen(false);
+              if (window.innerWidth >= 1280) {
+                setIsCollapsed(false);
+              }
+              return;
+            }
+            setIsCollapsed(true);
+            setTimeout(() => {
+              setIsSearchOpen(true);
+            }, 150);
+          }}
           className={`
-                relative flex items-center 
-                transition-all duration-300 ease-in-out 
-                overflow-hidden cursor-pointer
+            relative flex items-center 
+            transition-all duration-300 ease-in-out 
+            overflow-hidden cursor-pointer
             ${
               isCollapsed
                 ? 'w-10 h-10 rounded-full justify-center'
@@ -254,6 +274,20 @@ export default function Sidebar() {
           </div>
         )}
       </nav>
+
+      {isSearchOpen && (
+        <div ref={searchPanelRef}>
+          <SearchPanel
+            onClose={() => {
+              setIsSearchOpen(false);
+
+              if (window.innerWidth >= 1280) {
+                setIsCollapsed(false);
+              }
+            }}
+          />
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -161,6 +161,7 @@ export default function Sidebar() {
 
         {isSearchOpen && (
           <SearchPanel
+            initialKeyword={sidebarKeyword}
             onClose={closePanelFn}
             onSearch={(keyword: string) => setSidebarKeyword(keyword)}
           />

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -16,6 +16,7 @@ export default function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [openPanel, setOpenPanel] = useState<OpenPanel>('none');
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [sidebarKeyword, setSidebarKeyword] = useState('');
 
   const pathname = usePathname();
   const router = useRouter();
@@ -147,6 +148,7 @@ export default function Sidebar() {
             <input
               type="text"
               readOnly
+              value={sidebarKeyword}
               placeholder="Search"
               className={`
           bg-transparent text-sm outline-none
@@ -166,6 +168,7 @@ export default function Sidebar() {
                 setIsCollapsed(false);
               }
             }}
+            onSearch={(keyword: string) => setSidebarKeyword(keyword)}
           />
         )}
       </div>

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -5,12 +5,14 @@ import { Search } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import MorePanel from './MorePanel';
 import { guestMenu, loggedInMenu } from './SideBarMenu';
 
 export default function Sidebar() {
   const { loginUser, isLogin, logout } = useAuth();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
 
   const pathname = usePathname();
   const router = useRouter();
@@ -36,18 +38,20 @@ export default function Sidebar() {
   // 외부 클릭 시 popover 닫기
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
+      // 로그아웃 모달이 열려있으면 외부 클릭 무시
+      if (showLogoutModal) return;
+
       if (moreModalRef.current && !moreModalRef.current.contains(e.target as Node)) {
         setIsMoreOpen(false);
+        // 패널이 닫힐 때 화면이 크면 확대모드로 전환
+        if (window.innerWidth >= 1280) {
+          setIsCollapsed(false);
+        }
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleLogout = async () => {
-    setIsMoreOpen(false);
-    await logout();
-  };
+  }, [showLogoutModal]);
 
   return (
     <aside
@@ -98,7 +102,7 @@ export default function Sidebar() {
               flex items-center justify-center w-7 h-7 pointer-events-none
             "
           >
-            <Search size={22} className={isCollapsed ? 'text-blue-600' : 'text-gray-700'} />
+            <Search size={22} />
           </div>
 
           {/* input은 확장 모드일 때만 렌더
@@ -121,6 +125,73 @@ export default function Sidebar() {
         {menu.map((item) => {
           const isActive =
             item.href === '/profile' ? pathname.startsWith('/profile') : pathname === item.href;
+
+          if (item.label === '더보기') {
+            const isMoreActive = isMoreOpen;
+
+            return (
+              <div key={item.label} className="relative group" ref={moreModalRef}>
+                <button
+                  onClick={() => {
+                    if (isMoreOpen) {
+                      setIsMoreOpen(false);
+                      if (window.innerWidth >= 1280) setIsCollapsed(false);
+                    } else {
+                      setIsCollapsed(true);
+                      setTimeout(() => setIsMoreOpen(true), 150);
+                    }
+                  }}
+                  className={`
+                    flex items-center gap-3 px-4 py-2 rounded-lg transition-all
+                    ${isMoreActive ? 'text-blue-600 font-medium' : 'text-gray-800 hover:bg-gray-100'}
+                  `}
+                >
+                  <div className="flex items-center justify-center w-7 h-7 flex-shrink-0">
+                    <item.icon size={24} />
+                  </div>
+
+                  <span
+                    className={`
+                      whitespace-nowrap transition-all duration-300
+                      ${isCollapsed ? 'w-0 opacity-0 overflow-hidden' : 'w-auto opacity-100'}
+                    `}
+                  >
+                    {item.label}
+                  </span>
+                </button>
+
+                {/* 축소 모드 툴팁 */}
+                {isCollapsed && (
+                  <span
+                    className="
+                      absolute left-20 top-1/2 -translate-y-1/2
+                      px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0
+                      group-hover:opacity-100 transition pointer-events-none 
+                      whitespace-nowrap
+                    "
+                  >
+                    {item.label}
+                  </span>
+                )}
+
+                {/* ⭐ 패널을 wrapper 안으로 이동 — 이제 패널 내부 클릭은 ref 내부로 인식됨! */}
+                {isMoreOpen && (
+                  <MorePanel
+                    onClose={() => {
+                      setIsMoreOpen(false);
+
+                      // 🔥 화면이 넓으면 다시 확장 상태로 돌아가기
+                      if (window.innerWidth >= 1280) {
+                        setIsCollapsed(false);
+                      }
+                    }}
+                    showLogoutModal={showLogoutModal}
+                    setShowLogoutModal={setShowLogoutModal}
+                  />
+                )}
+              </div>
+            );
+          }
 
           return (
             <div key={item.label} className="relative group">

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -13,6 +13,7 @@ type OpenPanel = 'none' | 'more' | 'search';
 
 export default function Sidebar() {
   const { loginUser, isLogin } = useAuth();
+
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [openPanel, setOpenPanel] = useState<OpenPanel>('none');
   const [showLogoutModal, setShowLogoutModal] = useState(false);
@@ -21,7 +22,6 @@ export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
 
-  // 패널 ref들 (외부 클릭 감지용)
   const moreModalRef = useRef<HTMLDivElement>(null);
   const searchWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -30,22 +30,35 @@ export default function Sidebar() {
   const isMoreOpen = openPanel === 'more';
   const isSearchOpen = openPanel === 'search';
 
-  // 화면 크기에 따라 자동으로 collapse
+  const openPanelFn = (panel: OpenPanel) => {
+    setOpenPanel(panel);
+    setIsCollapsed(true); // 패널 열면 자동 축소
+  };
+
+  const closePanelFn = () => {
+    setOpenPanel('none');
+    setIsCollapsed(false); // 패널 닫으면 원래 크기
+  };
+
   useEffect(() => {
     function handleResize() {
       if (window.innerWidth < 1280) {
         setIsCollapsed(true);
       } else {
-        setIsCollapsed(false);
+        // 패널이 열려있으면 collapsed 유지
+        if (openPanel === 'none') {
+          setIsCollapsed(false);
+        }
       }
     }
-
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [openPanel]);
 
-  // 외부 클릭 시 패널 공통 닫기 (More, Search 모두 여기서 처리)
+  /* ============================================================
+        외부 클릭 시 패널 닫기 (collapse는 변경 금지!)
+     ============================================================ */
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (showLogoutModal) return;
@@ -56,48 +69,49 @@ export default function Sidebar() {
       const clickedInsideSearch =
         searchWrapperRef.current && searchWrapperRef.current.contains(target);
 
-      // 🔹 검색 패널이 열려 있을 때 바깥 클릭 → 닫기
       if (openPanel === 'search' && !clickedInsideSearch) {
-        setOpenPanel('none');
-        if (window.innerWidth >= 1280) {
-          setIsCollapsed(false);
-        }
+        closePanelFn();
         return;
       }
 
-      // 🔹 더보기 패널이 열려 있을 때 바깥 클릭 → 닫기
       if (openPanel === 'more' && !clickedInsideMore) {
-        setOpenPanel('none');
-        if (window.innerWidth >= 1280) {
-          setIsCollapsed(false);
-        }
+        closePanelFn();
         return;
       }
     }
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showLogoutModal, openPanel]);
+  }, [openPanel, showLogoutModal]);
+
+  /* ============================================================
+        검색 페이지 벗어난 경우 사이드바 검색어 초기화
+     ============================================================ */
+  useEffect(() => {
+    if (!pathname.startsWith('/search')) {
+      setSidebarKeyword('');
+    }
+  }, [pathname]);
 
   return (
     <aside
       className={`
         ${isCollapsed ? 'w-20' : 'w-60'}
-        bg-white border-r border-gray-200 h-screen fixed flex flex-col transition-all duration-300
+        bg-white border-r border-gray-200
+        h-screen fixed flex flex-col
+        transition-all duration-300
       `}
     >
-      {/* ======================= HEADER ======================= */}
+      {/* ================= HEADER ================= */}
       <div className="p-5 flex items-center justify-between">
         <div className="flex items-center gap-6">
-          {/* FIXED: 아이콘 크기 고정 */}
           <div className="w-10 h-10 bg-gray-200 rounded-lg flex-shrink-0 flex items-center justify-center">
             📝
           </div>
 
-          {/* label만 나타나고 사라짐 — 아이콘 위치는 고정 */}
           <div
             className={`
-              overflow-hidden transition-all 
+              transition-all overflow-hidden
               ${isCollapsed ? 'w-0 opacity-0' : 'w-auto opacity-100'}
             `}
           >
@@ -106,41 +120,27 @@ export default function Sidebar() {
         </div>
       </div>
 
-      {/* ======================= SEARCH AREA ======================= */}
-      {/* ======================= SEARCH AREA + PANEL WRAPPER ======================= */}
+      {/* =============== SEARCH + PANEL WRAPPER =============== */}
       <div ref={searchWrapperRef}>
         <div className="px-4 py-1 flex justify-start">
           <div
             onClick={() => {
-              if (isSearchOpen) {
-                // 이미 열려있으면 → 닫기 + 사이드바 확장
-                setOpenPanel('none');
-                if (window.innerWidth >= 1280) {
-                  setIsCollapsed(false);
-                }
-                return;
-              }
-              // 닫혀있으면 → 열기 + 사이드바 축소
-              setOpenPanel('search');
-              setIsCollapsed(true);
+              if (isSearchOpen) closePanelFn();
+              else openPanelFn('search');
             }}
             className={`
-        relative flex items-center 
-        transition-all duration-300 ease-in-out 
-        overflow-hidden cursor-pointer
-        ${
-          isCollapsed
-            ? 'w-10 h-10 rounded-full justify-center'
-            : 'w-full h-10 rounded-full bg-gray-100 pl-12 pr-3 border border-gray-200'
-        }
-      `}
+              relative flex items-center cursor-pointer overflow-hidden
+              transition-all duration-300 ease-in-out
+              ${
+                isCollapsed
+                  ? 'w-10 h-10 rounded-full justify-center'
+                  : 'w-full h-10 rounded-full bg-gray-100 pl-12 pr-3 border border-gray-200'
+              }
+            `}
           >
-            {/* 🔍 아이콘 */}
             <div
-              className="
-          absolute left-3 top-1/2 -translate-y-1/2 
-          flex items-center justify-center w-7 h-7 pointer-events-none
-        "
+              className="absolute left-3 top-1/2 -translate-y-1/2 
+                         flex items-center justify-center w-7 h-7 pointer-events-none"
             >
               <Search size={22} />
             </div>
@@ -151,23 +151,17 @@ export default function Sidebar() {
               value={sidebarKeyword}
               placeholder="Search"
               className={`
-          bg-transparent text-sm outline-none
-          transition-all duration-300 ease-in-out
-          ${isCollapsed ? 'w-0 opacity-0' : 'w-full opacity-100'}
-        `}
+                bg-transparent text-sm outline-none
+                transition-all duration-300
+                ${isCollapsed ? 'w-0 opacity-0' : 'w-full opacity-100'}
+              `}
             />
           </div>
         </div>
 
-        {/* 검색 패널 */}
         {isSearchOpen && (
           <SearchPanel
-            onClose={() => {
-              setOpenPanel('none');
-              if (window.innerWidth >= 1280) {
-                setIsCollapsed(false);
-              }
-            }}
+            onClose={closePanelFn}
             onSearch={(keyword: string) => setSidebarKeyword(keyword)}
           />
         )}
@@ -184,15 +178,8 @@ export default function Sidebar() {
               <div key={item.label} className="relative group" ref={moreModalRef}>
                 <button
                   onClick={() => {
-                    if (isMoreOpen) {
-                      // 이미 열려있으면 → 닫기
-                      setOpenPanel('none');
-                      if (window.innerWidth >= 1280) setIsCollapsed(false);
-                    } else {
-                      // 더보기 패널 열기
-                      setOpenPanel('more');
-                      setIsCollapsed(true);
-                    }
+                    if (isMoreOpen) closePanelFn();
+                    else openPanelFn('more');
                   }}
                   className={`
                     flex items-center gap-3 px-4 py-2 rounded-lg transition-all
@@ -213,29 +200,21 @@ export default function Sidebar() {
                   </span>
                 </button>
 
-                {/* 축소 모드 툴팁 */}
                 {isCollapsed && (
                   <span
                     className="
                       absolute left-20 top-1/2 -translate-y-1/2
-                      px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0
-                      group-hover:opacity-100 transition pointer-events-none 
-                      whitespace-nowrap
+                      px-2 py-1 bg-gray-900 text-white text-xs rounded
+                      opacity-0 group-hover:opacity-100 transition pointer-events-none
                     "
                   >
                     {item.label}
                   </span>
                 )}
 
-                {/* 더보기 패널 */}
                 {isMoreOpen && (
                   <MorePanel
-                    onClose={() => {
-                      setOpenPanel('none');
-                      if (window.innerWidth >= 1280) {
-                        setIsCollapsed(false);
-                      }
-                    }}
+                    onClose={closePanelFn}
                     showLogoutModal={showLogoutModal}
                     setShowLogoutModal={setShowLogoutModal}
                   />
@@ -253,7 +232,6 @@ export default function Sidebar() {
                   ${isActive ? 'text-blue-600 font-medium' : 'text-gray-800 hover:bg-gray-100'}
                 `}
               >
-                {/* FIXED: 아이콘 위치 완전 고정 */}
                 <div className="flex items-center justify-center w-7 h-7 flex-shrink-0">
                   {item.label === '프로필' && isLogin ? (
                     <img
@@ -266,7 +244,6 @@ export default function Sidebar() {
                   )}
                 </div>
 
-                {/* label만 사라짐 — 아이콘은 그대로 */}
                 <span
                   className={`
                     whitespace-nowrap transition-all
@@ -277,14 +254,12 @@ export default function Sidebar() {
                 </span>
               </Link>
 
-              {/* 축소 모드 툴팁 */}
               {isCollapsed && (
                 <span
                   className="
                     absolute left-20 top-1/2 -translate-y-1/2
-                    px-2 py-1 bg-gray-900 text-white text-xs rounded opacity-0
-                    group-hover:opacity-100 transition pointer-events-none 
-                    whitespace-nowrap
+                    px-2 py-1 bg-gray-900 text-white text-xs rounded
+                    opacity-0 group-hover:opacity-100 transition pointer-events-none
                   "
                 >
                   {item.label}

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -22,13 +22,13 @@ export default function Sidebar() {
   useEffect(() => {
     function handleResize() {
       if (window.innerWidth < 1280) {
-        setIsCollapsed(true); // 브라우저가 좁아지면 자동 축소
+        setIsCollapsed(true);
       } else {
-        setIsCollapsed(false); // 다시 넓어지면 자동 확장
+        setIsCollapsed(false);
       }
     }
 
-    handleResize(); // 초기 실행
+    handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
@@ -44,7 +44,6 @@ export default function Sidebar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // 로그아웃 처리
   const handleLogout = async () => {
     setIsMoreOpen(false);
     await logout();
@@ -57,50 +56,64 @@ export default function Sidebar() {
         bg-white border-r border-gray-200 h-screen fixed flex flex-col transition-all duration-300
       `}
     >
-      {/* ======================= HEADER (로고 + 축소 토글) ======================= */}
+      {/* ======================= HEADER ======================= */}
       <div className="p-5 border-b border-gray-200 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <div className="w-9 h-9 bg-gray-200 rounded-lg flex-shrink-0 flex items-center justify-center">
+          {/* FIXED: 아이콘 크기 고정 */}
+          <div className="w-10 h-10 bg-gray-200 rounded-lg flex-shrink-0 flex items-center justify-center">
             📝
           </div>
-          {!isCollapsed && (
-            <div className="flex flex-col leading-tight">
-              <span className="font-bold text-xl">TEXTOK</span>
-            </div>
-          )}
+
+          {/* label만 나타나고 사라짐 — 아이콘 위치는 고정 */}
+          <div
+            className={`
+              overflow-hidden transition-all 
+              ${isCollapsed ? 'w-0 opacity-0' : 'w-auto opacity-100'}
+            `}
+          >
+            <span className="font-bold text-xl whitespace-nowrap">TEXTOK</span>
+          </div>
         </div>
       </div>
 
       {/* ======================= SEARCH AREA ======================= */}
-      <div className="px-4 py-4 flex justify-center">
-        {isCollapsed ? (
-          // 축소 모드 → 원형 안에 검색 아이콘, 크기 정렬 통일
-          <button
-            onClick={() => setIsCollapsed(false)}
+      <div className="px-4 py-3 flex justify-start">
+        <div
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className={`
+                relative flex items-center 
+                transition-all duration-300 ease-in-out 
+                overflow-hidden cursor-pointer
+            ${
+              isCollapsed
+                ? 'w-10 h-10 rounded-full justify-center'
+                : 'w-full h-10 rounded-full bg-gray-100 pl-12 pr-3 border border-gray-200'
+            }
+          `}
+        >
+          {/* 🔍 아이콘 (항상 같은 위치에 고정) */}
+          <div
             className="
-              w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center 
-              hover:bg-gray-200 transition
+              absolute left-3 top-1/2 -translate-y-1/2 
+              flex items-center justify-center w-7 h-7 pointer-events-none
             "
           >
-            <Search size={22} className="text-gray-700" />
-          </button>
-        ) : (
-          // 확장 모드 → 검색바 내부 아이콘도 정렬 축 통일
-          <div className="relative w-full cursor-pointer" onClick={() => setIsCollapsed(true)}>
-            <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center justify-center w-7 h-7">
-              <Search size={22} className="text-gray-700" />
-            </div>
-
-            <input
-              type="text"
-              placeholder="Search"
-              className="
-                w-full pl-12 pr-3 py-2 bg-gray-100 rounded-full text-sm border border-gray-200
-                focus:outline-none focus:border-blue-500
-              "
-            />
+            <Search size={22} className={isCollapsed ? 'text-blue-600' : 'text-gray-700'} />
           </div>
-        )}
+
+          {/* input은 확장 모드일 때만 렌더
+        collapse에서는 width:0 되도록 해서 자연스럽게 사라짐 */}
+          <input
+            type="text"
+            readOnly
+            placeholder="Search"
+            className={`
+              bg-transparent text-sm outline-none
+              transition-all duration-300 ease-in-out
+              ${isCollapsed ? 'w-0 opacity-0' : 'w-full opacity-100'}
+            `}
+          />
+        </div>
       </div>
 
       {/* ======================= MENU LIST ======================= */}
@@ -114,17 +127,32 @@ export default function Sidebar() {
               <Link
                 href={item.href}
                 className={`
-                  flex items-center 
-                  ${isCollapsed ? 'justify-center' : 'justify-start gap-3 px-4'}
-                  py-2 rounded-lg transition-all
+                  flex items-center gap-3 px-4 py-2 rounded-lg transition-all
                   ${isActive ? 'text-blue-600 font-medium' : 'text-gray-800 hover:bg-gray-100'}
                 `}
               >
+                {/* FIXED: 아이콘 위치 완전 고정 */}
                 <div className="flex items-center justify-center w-7 h-7 flex-shrink-0">
-                  <item.icon size={24} />
+                  {item.label === '프로필' && isLogin ? (
+                    <img
+                      src={loginUser?.profileImgUrl || '/tmpProfile.png'}
+                      alt="profile"
+                      className="w-7 h-7 rounded-full object-cover"
+                    />
+                  ) : (
+                    <item.icon size={24} />
+                  )}
                 </div>
 
-                {!isCollapsed && <span>{item.label}</span>}
+                {/* label만 사라짐 — 아이콘은 그대로 */}
+                <span
+                  className={`
+                    whitespace-nowrap transition-all
+                    ${isCollapsed ? 'w-0 opacity-0 overflow-hidden' : 'w-auto opacity-100'}
+                  `}
+                >
+                  {item.label}
+                </span>
               </Link>
 
               {/* 축소 모드 툴팁 */}
@@ -144,7 +172,6 @@ export default function Sidebar() {
           );
         })}
 
-        {/* 로그인 버튼 (확장일때만) */}
         {!isLogin && !isCollapsed && (
           <div className="pt-2 pb-6 border-b border-gray-200">
             <button

--- a/src/app/components/sidebar/SideBar.tsx
+++ b/src/app/components/sidebar/SideBar.tsx
@@ -5,8 +5,8 @@ import { Search } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
-import MorePanel from './MorePanel';
-import SearchPanel from './SearchPanel';
+import MorePanel from './panel/MorePanel';
+import SearchPanel from './panel/SearchPanel';
 import { guestMenu, loggedInMenu } from './SideBarMenu';
 
 type OpenPanel = 'none' | 'more' | 'search';

--- a/src/app/components/sidebar/SideBarMenu.tsx
+++ b/src/app/components/sidebar/SideBarMenu.tsx
@@ -25,7 +25,7 @@ export const guestMenu: MenuItem[] = [
   { icon: Users, label: '팔로우', href: '/follow' },
   { icon: PlusSquare, label: '작성', href: '/create-content' },
   { icon: User, label: '프로필', href: '/profile' },
-  { icon: MoreHorizontal, label: '더보기', href: '/more' },
+  { icon: MoreHorizontal, label: '더보기', href: '' },
 ];
 
 // 로그인 메뉴
@@ -38,5 +38,5 @@ export const loggedInMenu: MenuItem[] = [
   { icon: MessageCircle, label: '메시지', href: '/messages', alert: true },
   { icon: Bell, label: '알림', href: '/notifications', alert: true },
   { icon: User, label: '프로필', href: '/profile' },
-  { icon: MoreHorizontal, label: '더보기', href: '/more' },
+  { icon: MoreHorizontal, label: '더보기', href: '' },
 ];

--- a/src/app/components/sidebar/panel/MorePanel.tsx
+++ b/src/app/components/sidebar/panel/MorePanel.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/src/providers/AuthProvider';
 import { X } from 'lucide-react';
 
 // ⭐ 추가: 모달 import
-import ConfirmLogoutModal from './ConfirmLogoutModal';
+import ConfirmLogoutModal from '../ConfirmLogoutModal';
 
 export default function MorePanel({
   onClose,

--- a/src/app/components/sidebar/panel/SearchPanel.tsx
+++ b/src/app/components/sidebar/panel/SearchPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from '@/src/providers/AuthProvider';
 import { Clock, Search, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -24,10 +25,10 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
   const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([]);
   const [autocomplete, setAutocomplete] = useState<RecommendedKeyword[]>([]);
   const [loading, setLoading] = useState(true);
-
   const debouncedKeyword = useDebounce(keyword, 300); // 0.3초 후 요청
+  const router = useRouter();
 
-  // 🔥 추천 검색어 + 내 검색 기록 병렬 호출
+  // 추천 검색어 + 내 검색 기록 병렬 호출
   useEffect(() => {
     async function loadAll() {
       try {
@@ -49,6 +50,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
     loadAll();
   }, [isLogin]);
 
+  // 자동완성
   useEffect(() => {
     async function loadAutocomplete() {
       if (!debouncedKeyword.trim()) {
@@ -63,6 +65,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
     loadAutocomplete();
   }, [debouncedKeyword]);
 
+  // 검색 기록 삭제
   const handleDeleteHistory = async (id: number) => {
     const success = await deleteSearchHistory(id);
     if (success) {
@@ -70,16 +73,12 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
     }
   };
 
-  // 자동완성 더미 (나중에 API 연동 가능)
-  const autoList = keyword
-    ? [
-        `${keyword} 강의`,
-        `${keyword} console`,
-        `${keyword} 추천`,
-        `${keyword} ec2`,
-        `${keyword} s3`,
-      ]
-    : [];
+  // 검색어 입력 시 검색 실행
+  const handleSearch = (keyword: string) => {
+    if (!keyword.trim()) return;
+    router.push(`/search/shorlog?keyword=${encodeURIComponent(keyword)}`);
+    onClose();
+  };
 
   const showRecommendedOnly = !keyword && !isLogin;
   const showRecentAndRecommend = !keyword && isLogin;
@@ -112,6 +111,11 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
             placeholder="검색어를 입력하세요"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSearch(keyword);
+              }
+            }}
             className="
               w-full h-10 bg-gray-100 rounded-full pl-4 pr-10
               text-[15px] outline-none border border-gray-200
@@ -139,6 +143,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
                 {autocomplete.map((item) => (
                   <li
                     key={item.keyword}
+                    onClick={() => handleSearch(item.keyword)}
                     className="flex items-center gap-2 px-2 py-2 rounded-lg hover:bg-gray-100 cursor-pointer"
                   >
                     <Search size={18} className="text-gray-500" />
@@ -159,6 +164,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
                   {searchHistory.map((item) => (
                     <li
                       key={item.id}
+                      onClick={() => handleSearch(item.keyword)}
                       className="flex items-center gap-2 px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
                     >
                       <div className="w-4 h-4 flex items-center justify-center">
@@ -188,6 +194,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
                   {top10Keywords.map((item) => (
                     <li
                       key={item.keyword}
+                      onClick={() => handleSearch(item.keyword)}
                       className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer flex items-center gap-2"
                     >
                       • {item.keyword}
@@ -206,6 +213,7 @@ export default function SearchPanel({ onClose }: { onClose: () => void }) {
                 {top10Keywords.map((item) => (
                   <li
                     key={item.keyword}
+                    onClick={() => handleSearch(item.keyword)}
                     className="px-1 py-1 rounded-lg hover:bg-gray-100 cursor-pointer"
                   >
                     • {item.keyword}

--- a/src/app/components/sidebar/panel/SearchPanel.tsx
+++ b/src/app/components/sidebar/panel/SearchPanel.tsx
@@ -21,12 +21,14 @@ type SearchHistoryItem = {
 export default function SearchPanel({
   onClose,
   onSearch,
+  initialKeyword = '',
 }: {
   onClose: () => void;
   onSearch: (keyword: string) => void;
+  initialKeyword?: string;
 }) {
   const { isLogin } = useAuth();
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useState(initialKeyword);
   const [top10Keywords, setTop10Keywords] = useState<RecommendedKeyword[]>([]);
   const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([]);
   const [autocomplete, setAutocomplete] = useState<RecommendedKeyword[]>([]);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,4 +7,3 @@
     @apply bg-white text-text;
   }
 }
-

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,3 +7,18 @@
     @apply bg-white text-text;
   }
 }
+
+@keyframes slideIn {
+  from {
+    transform: translateX(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.animate-slideIn {
+  animation: slideIn 0.25s ease-out forwards;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <Sidebar />
               <main
                 className="
-                  flex-1 bg-slate-50 
+                  flex-1 bg-white 
                   pl-20 
                   xl:pl-60
                   transition-all duration-300

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ReactQueryProvider>
             <div className="flex min-h-screen">
               <Sidebar />
-              <main className="ml-64 flex-1">{children}</main>
+              <main
+                className="
+                  flex-1 bg-slate-50 
+                  pl-20 
+                  xl:pl-60
+                  transition-all duration-300
+                "
+              >
+                {children}
+              </main>
             </div>
           </ReactQueryProvider>
         </AuthProvider>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const isMyPage = currentUserId === id;
 
   return (
-    <div className="min-h-screen text-slate-900">
+    <div className="min-h-screen bg-white text-slate-900">
       <div className="flex">
         <main className="flex-1 min-h-screen">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-10 py-8">

--- a/src/app/search/SearchLayoutClient.tsx
+++ b/src/app/search/SearchLayoutClient.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+// 탭 목록
+const tabs = [
+  { key: 'shorlog', label: '숏로그' },
+  { key: 'blog', label: '블로그' },
+  { key: 'user', label: '사용자' },
+];
+
+// 탭별 정렬 옵션 분기
+const sortMap: Record<string, { key: string; label: string }[] | null> = {
+  shorlog: [
+    { key: 'latest', label: '최신' },
+    { key: 'popular', label: '인기' },
+    { key: 'view', label: '조회수' },
+  ],
+  blog: [
+    { key: 'latest', label: '최신' },
+    { key: 'popular', label: '인기' },
+  ],
+  user: null, // 사용자 탭은 정렬 없음
+};
+
+export default function SearchLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const pathname = usePathname();
+
+  const keyword = params.get('keyword') || '';
+  const activeTab = pathname.split('/').pop() || 'shorlog';
+
+  // 현재 탭 기준 정렬 옵션 목록
+  const availableSorts = sortMap[activeTab];
+
+  // sort param은 없을 수도 있으므로 기본값 처리
+  const currentSort = params.get('sort') || (availableSorts ? availableSorts[0].key : '');
+
+  // 탭 이동
+  const moveTab = (tab: string) => {
+    router.push(`/search/${tab}?keyword=${encodeURIComponent(keyword)}`);
+  };
+
+  // 정렬 변경
+  const changeSort = (sort: string) => {
+    router.push(`/search/${activeTab}?keyword=${encodeURIComponent(keyword)}&sort=${sort}`);
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-10 py-4">
+      {/* === 탭 + 정렬 === */}
+      <div className="flex items-end justify-between border-b border-slate-200">
+        {/* 왼쪽 탭 */}
+        <div className="flex gap-0 text-lg">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => moveTab(t.key)}
+              className={`
+                px-8 pb-2 border-b-2
+                ${
+                  activeTab === t.key
+                    ? 'border-slate-900 font-semibold'
+                    : 'border-transparent text-slate-500'
+                }
+              `}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 오른쪽 정렬 — user 탭은 없음 */}
+        {availableSorts && (
+          <div className="inline-flex items-center rounded-md bg-slate-100 p-0.5 text-[13px]">
+            {availableSorts.map((s) => (
+              <button
+                key={s.key}
+                onClick={() => changeSort(s.key)}
+                className={`
+                  px-3 py-1.5 rounded-md
+                  ${currentSort === s.key ? 'bg-white shadow text-slate-900' : 'text-slate-500'}
+                `}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* === 컨텐츠 === */}
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}

--- a/src/app/search/SearchPageClient.tsx
+++ b/src/app/search/SearchPageClient.tsx
@@ -1,0 +1,45 @@
+// app/search/page.tsx
+'use client';
+
+import SearchTabs from '@/src/app/components/search/SearchTabs';
+import SortFilter from '@/src/app/components/search/SortFilter';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function SearchPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const keyword = searchParams.get('keyword') || '';
+  const tab = searchParams.get('tab') || 'shortlog';
+  const sort = searchParams.get('sort') || 'latest';
+
+  // 검색어 없으면 빈 페이지 처리
+  if (!keyword) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <p className="text-gray-500 text-lg">검색어가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className="ml-20 px-8 py-6">
+      {' '}
+      {/* 사이드바가 fixed라서 margin-left 적용 */}
+      {/* 검색 키워드 */}
+      <h1 className="text-xl font-semibold mb-6">
+        검색 결과: <span className="font-bold text-blue-600">{keyword}</span>
+      </h1>
+      {/* Tabs */}
+      <SearchTabs keyword={keyword} activeTab={tab} />
+      {/* Sort Filter */}
+      {tab !== 'user' && <SortFilter keyword={keyword} currentTab={tab} currentSort={sort} />}
+      {/* Content */}
+      <div className="mt-6">
+        {tab === 'shortlog' && <div className="text-gray-500">📌 숏로그 결과 표시 예정</div>}
+        {tab === 'blog' && <div className="text-gray-500">📌 블로그 결과 표시 예정</div>}
+        {tab === 'user' && <div className="text-gray-500">📌 사용자 검색 결과 표시 예정</div>}
+      </div>
+    </main>
+  );
+}

--- a/src/app/search/blog/BlogSearchPageClient.tsx
+++ b/src/app/search/blog/BlogSearchPageClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function BlogSearchPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const keyword = params.get('keyword') || '';
+  const sort = params.get('sort');
+
+  // ⭐ 기본 정렬값: popular
+  useEffect(() => {
+    if (!sort) {
+      router.replace(`/search/blog?keyword=${encodeURIComponent(keyword)}&sort=popular`);
+    }
+  }, [sort, keyword]);
+
+  if (!sort) return null;
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold">블로그 검색 결과</h1>
+      {/* 블로그 검색 API 호출 로직 */}
+    </div>
+  );
+}

--- a/src/app/search/blog/page.tsx
+++ b/src/app/search/blog/page.tsx
@@ -1,28 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import BlogSearchPageClient from './BlogSearchPageClient';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
-
-export default function BlogSearchPage() {
-  const params = useSearchParams();
-  const router = useRouter();
-
-  const keyword = params.get('keyword') || '';
-  const sort = params.get('sort');
-
-  // ⭐ 기본 정렬값: popular
-  useEffect(() => {
-    if (!sort) {
-      router.replace(`/search/blog?keyword=${encodeURIComponent(keyword)}&sort=popular`);
-    }
-  }, [sort, keyword]);
-
-  if (!sort) return null;
-
+export default function Page() {
   return (
-    <div>
-      <h1 className="text-lg font-semibold">블로그 검색 결과</h1>
-      {/* 블로그 검색 API 호출 로직 */}
-    </div>
+    <Suspense fallback={null}>
+      <BlogSearchPageClient />
+    </Suspense>
   );
 }

--- a/src/app/search/blog/page.tsx
+++ b/src/app/search/blog/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function BlogSearchPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const keyword = params.get('keyword') || '';
+  const sort = params.get('sort');
+
+  // ⭐ 기본 정렬값: popular
+  useEffect(() => {
+    if (!sort) {
+      router.replace(`/search/blog?keyword=${encodeURIComponent(keyword)}&sort=popular`);
+    }
+  }, [sort, keyword]);
+
+  if (!sort) return null;
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold">블로그 검색 결과</h1>
+      {/* 블로그 검색 API 호출 로직 */}
+    </div>
+  );
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,97 +1,10 @@
-'use client';
-
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-
-// 탭 목록
-const tabs = [
-  { key: 'shorlog', label: '숏로그' },
-  { key: 'blog', label: '블로그' },
-  { key: 'user', label: '사용자' },
-];
-
-// 탭별 정렬 옵션 분기
-const sortMap: Record<string, { key: string; label: string }[] | null> = {
-  shorlog: [
-    { key: 'latest', label: '최신' },
-    { key: 'popular', label: '인기' },
-    { key: 'view', label: '조회수' },
-  ],
-  blog: [
-    { key: 'latest', label: '최신' },
-    { key: 'popular', label: '인기' },
-  ],
-  user: null, // 사용자 탭은 정렬 없음
-};
+import { Suspense } from 'react';
+import SearchLayoutClient from './SearchLayoutClient';
 
 export default function SearchLayout({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
-  const params = useSearchParams();
-  const pathname = usePathname();
-
-  const keyword = params.get('keyword') || '';
-  const activeTab = pathname.split('/').pop() || 'shorlog';
-
-  // 현재 탭 기준 정렬 옵션 목록
-  const availableSorts = sortMap[activeTab];
-
-  // sort param은 없을 수도 있으므로 기본값 처리
-  const currentSort = params.get('sort') || (availableSorts ? availableSorts[0].key : '');
-
-  // 탭 이동
-  const moveTab = (tab: string) => {
-    router.push(`/search/${tab}?keyword=${encodeURIComponent(keyword)}`);
-  };
-
-  // 정렬 변경
-  const changeSort = (sort: string) => {
-    router.push(`/search/${activeTab}?keyword=${encodeURIComponent(keyword)}&sort=${sort}`);
-  };
-
   return (
-    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-10 py-4">
-      {/* === 탭 + 정렬 === */}
-      <div className="flex items-end justify-between border-b border-slate-200">
-        {/* 왼쪽 탭 */}
-        <div className="flex gap-0 text-lg">
-          {tabs.map((t) => (
-            <button
-              key={t.key}
-              onClick={() => moveTab(t.key)}
-              className={`
-                px-8 pb-2 border-b-2
-                ${
-                  activeTab === t.key
-                    ? 'border-slate-900 font-semibold'
-                    : 'border-transparent text-slate-500'
-                }
-              `}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
-
-        {/* 오른쪽 정렬 — user 탭은 없음 */}
-        {availableSorts && (
-          <div className="inline-flex items-center rounded-md bg-slate-100 p-0.5 text-[13px]">
-            {availableSorts.map((s) => (
-              <button
-                key={s.key}
-                onClick={() => changeSort(s.key)}
-                className={`
-                  px-3 py-1.5 rounded-md
-                  ${currentSort === s.key ? 'bg-white shadow text-slate-900' : 'text-slate-500'}
-                `}
-              >
-                {s.label}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* === 컨텐츠 === */}
-      <div className="mt-6">{children}</div>
-    </div>
+    <Suspense fallback={null}>
+      <SearchLayoutClient>{children}</SearchLayoutClient>
+    </Suspense>
   );
 }

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+// 탭 목록
+const tabs = [
+  { key: 'shorlog', label: '숏로그' },
+  { key: 'blog', label: '블로그' },
+  { key: 'user', label: '사용자' },
+];
+
+// 탭별 정렬 옵션 분기
+const sortMap: Record<string, { key: string; label: string }[] | null> = {
+  shorlog: [
+    { key: 'latest', label: '최신' },
+    { key: 'popular', label: '인기' },
+    { key: 'view', label: '조회수' },
+  ],
+  blog: [
+    { key: 'latest', label: '최신' },
+    { key: 'popular', label: '인기' },
+  ],
+  user: null, // 사용자 탭은 정렬 없음
+};
+
+export default function SearchLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const pathname = usePathname();
+
+  const keyword = params.get('keyword') || '';
+  const activeTab = pathname.split('/').pop() || 'shorlog';
+
+  // 현재 탭 기준 정렬 옵션 목록
+  const availableSorts = sortMap[activeTab];
+
+  // sort param은 없을 수도 있으므로 기본값 처리
+  const currentSort = params.get('sort') || (availableSorts ? availableSorts[0].key : '');
+
+  // 탭 이동
+  const moveTab = (tab: string) => {
+    router.push(`/search/${tab}?keyword=${encodeURIComponent(keyword)}&sort=${currentSort}`);
+  };
+
+  // 정렬 변경
+  const changeSort = (sort: string) => {
+    router.push(`/search/${activeTab}?keyword=${encodeURIComponent(keyword)}&sort=${sort}`);
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-10 py-4">
+      {/* === 탭 + 정렬 === */}
+      <div className="flex items-end justify-between border-b border-slate-200">
+        {/* 왼쪽 탭 */}
+        <div className="flex gap-0 text-lg">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => moveTab(t.key)}
+              className={`
+                px-8 pb-2 border-b-2
+                ${
+                  activeTab === t.key
+                    ? 'border-slate-900 font-semibold'
+                    : 'border-transparent text-slate-500'
+                }
+              `}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 오른쪽 정렬 — user 탭은 없음 */}
+        {availableSorts && (
+          <div className="inline-flex items-center rounded-md bg-slate-100 p-0.5 text-[13px]">
+            {availableSorts.map((s) => (
+              <button
+                key={s.key}
+                onClick={() => changeSort(s.key)}
+                className={`
+                  px-3 py-1.5 rounded-md
+                  ${currentSort === s.key ? 'bg-white shadow text-slate-900' : 'text-slate-500'}
+                `}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* === 컨텐츠 === */}
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -39,7 +39,7 @@ export default function SearchLayout({ children }: { children: React.ReactNode }
 
   // 탭 이동
   const moveTab = (tab: string) => {
-    router.push(`/search/${tab}?keyword=${encodeURIComponent(keyword)}&sort=${currentSort}`);
+    router.push(`/search/${tab}?keyword=${encodeURIComponent(keyword)}`);
   };
 
   // 정렬 변경

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,44 +1,10 @@
-// app/search/page.tsx
+import { Suspense } from 'react';
+import SearchPageClient from './SearchPageClient';
 
-import SearchTabs from '@/src/app/components/search/SearchTabs';
-import SortFilter from '@/src/app/components/search/SortFilter';
-import { useRouter, useSearchParams } from 'next/navigation';
-
-export default function SearchPage() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-
-  const keyword = searchParams.get('keyword') || '';
-  const tab = searchParams.get('tab') || 'shortlog';
-  const sort = searchParams.get('sort') || 'latest';
-
-  // 검색어 없으면 빈 페이지 처리
-  if (!keyword) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full">
-        <p className="text-gray-500 text-lg">검색어가 없습니다.</p>
-      </div>
-    );
-  }
-
+export default function Page() {
   return (
-    <main className="ml-20 px-8 py-6">
-      {' '}
-      {/* 사이드바가 fixed라서 margin-left 적용 */}
-      {/* 검색 키워드 */}
-      <h1 className="text-xl font-semibold mb-6">
-        검색 결과: <span className="font-bold text-blue-600">{keyword}</span>
-      </h1>
-      {/* Tabs */}
-      <SearchTabs keyword={keyword} activeTab={tab} />
-      {/* Sort Filter */}
-      {tab !== 'user' && <SortFilter keyword={keyword} currentTab={tab} currentSort={sort} />}
-      {/* Content */}
-      <div className="mt-6">
-        {tab === 'shortlog' && <div className="text-gray-500">📌 숏로그 결과 표시 예정</div>}
-        {tab === 'blog' && <div className="text-gray-500">📌 블로그 결과 표시 예정</div>}
-        {tab === 'user' && <div className="text-gray-500">📌 사용자 검색 결과 표시 예정</div>}
-      </div>
-    </main>
+    <Suspense>
+      <SearchPageClient />
+    </Suspense>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,45 @@
+// app/search/page.tsx
+'use client';
+
+import SearchTabs from '@/src/app/components/search/SearchTabs';
+import SortFilter from '@/src/app/components/search/SortFilter';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function SearchPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const keyword = searchParams.get('keyword') || '';
+  const tab = searchParams.get('tab') || 'shortlog';
+  const sort = searchParams.get('sort') || 'latest';
+
+  // 검색어 없으면 빈 페이지 처리
+  if (!keyword) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <p className="text-gray-500 text-lg">검색어가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className="ml-20 px-8 py-6">
+      {' '}
+      {/* 사이드바가 fixed라서 margin-left 적용 */}
+      {/* 검색 키워드 */}
+      <h1 className="text-xl font-semibold mb-6">
+        검색 결과: <span className="font-bold text-blue-600">{keyword}</span>
+      </h1>
+      {/* Tabs */}
+      <SearchTabs keyword={keyword} activeTab={tab} />
+      {/* Sort Filter */}
+      {tab !== 'user' && <SortFilter keyword={keyword} currentTab={tab} currentSort={sort} />}
+      {/* Content */}
+      <div className="mt-6">
+        {tab === 'shortlog' && <div className="text-gray-500">📌 숏로그 결과 표시 예정</div>}
+        {tab === 'blog' && <div className="text-gray-500">📌 블로그 결과 표시 예정</div>}
+        {tab === 'user' && <div className="text-gray-500">📌 사용자 검색 결과 표시 예정</div>}
+      </div>
+    </main>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,5 +1,4 @@
 // app/search/page.tsx
-'use client';
 
 import SearchTabs from '@/src/app/components/search/SearchTabs';
 import SortFilter from '@/src/app/components/search/SortFilter';

--- a/src/app/search/shorlog/ShorlogSearchPageClient.tsx
+++ b/src/app/search/shorlog/ShorlogSearchPageClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ShortlogSearchPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const keyword = params.get('keyword') || '';
+  const sort = params.get('sort');
+
+  // ⭐ 기본 정렬값 지정: latest
+  useEffect(() => {
+    if (!sort) {
+      router.replace(`/search/shorlog?keyword=${encodeURIComponent(keyword)}&sort=latest`);
+    }
+  }, [sort, keyword]);
+
+  if (!sort) return null; // redirect 처리 중
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold">숏로그 검색 결과</h1>
+      {/* 숏로그 검색 API 호출 로직 */}
+    </div>
+  );
+}

--- a/src/app/search/shorlog/page.tsx
+++ b/src/app/search/shorlog/page.tsx
@@ -1,28 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import ShorlogSearchPageClient from './ShorlogSearchPageClient';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
-
-export default function ShortlogSearchPage() {
-  const params = useSearchParams();
-  const router = useRouter();
-
-  const keyword = params.get('keyword') || '';
-  const sort = params.get('sort');
-
-  // ⭐ 기본 정렬값 지정: latest
-  useEffect(() => {
-    if (!sort) {
-      router.replace(`/search/shorlog?keyword=${encodeURIComponent(keyword)}&sort=latest`);
-    }
-  }, [sort, keyword]);
-
-  if (!sort) return null; // redirect 처리 중
-
+export default function Page() {
   return (
-    <div>
-      <h1 className="text-lg font-semibold">숏로그 검색 결과</h1>
-      {/* 숏로그 검색 API 호출 로직 */}
-    </div>
+    <Suspense fallback={null}>
+      <ShorlogSearchPageClient />
+    </Suspense>
   );
 }

--- a/src/app/search/shorlog/page.tsx
+++ b/src/app/search/shorlog/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ShortlogSearchPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  const keyword = params.get('keyword') || '';
+  const sort = params.get('sort');
+
+  // ⭐ 기본 정렬값 지정: latest
+  useEffect(() => {
+    if (!sort) {
+      router.replace(`/search/shorlog?keyword=${encodeURIComponent(keyword)}&sort=latest`);
+    }
+  }, [sort, keyword]);
+
+  if (!sort) return null; // redirect 처리 중
+
+  return (
+    <div>
+      <h1 className="text-lg font-semibold">숏로그 검색 결과</h1>
+      {/* 숏로그 검색 API 호출 로직 */}
+    </div>
+  );
+}

--- a/src/app/search/user/UserSearchPageClient.tsx
+++ b/src/app/search/user/UserSearchPageClient.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+type UserSearchResult = {
+  id: number;
+  nickname: string;
+  profileImgUrl: string | null;
+  bio: string;
+  followersCount: number;
+};
+
+export default function SearchUserPage() {
+  const params = useSearchParams();
+  const keyword = params.get('keyword') || '';
+  const [users, setUsers] = useState<UserSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      if (!keyword.trim()) return;
+
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${API_BASE_URL}/api/v1/users/search?keyword=${encodeURIComponent(keyword)}`,
+          {
+            method: 'GET',
+            credentials: 'include',
+          },
+        );
+
+        if (!res.ok) throw new Error('검색 실패');
+
+        const json = await res.json();
+        setUsers(json.data || []);
+      } catch (e) {
+        console.error(e);
+      }
+      setLoading(false);
+    }
+
+    load();
+  }, [keyword]);
+
+  return (
+    <div className="mt-4">
+      {loading ? (
+        <div className="text-center text-sm text-slate-500">불러오는 중...</div>
+      ) : users.length === 0 ? (
+        <div className="text-center text-sm text-slate-500">검색 결과가 없습니다.</div>
+      ) : (
+        <div className="space-y-1">
+          {users.map((user) => (
+            <a
+              key={user.id}
+              href={`/profile/${user.id}`}
+              className="flex items-center gap-4 p-4 rounded-md bg-white hover:bg-slate-50 transition"
+            >
+              {/* 프로필 이미지 */}
+              <img
+                src={user.profileImgUrl || '/tmpProfile.png'}
+                alt="profile"
+                className="w-14 h-14 rounded-full object-cover bg-slate-200"
+              />
+
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-slate-900">{user.nickname}</span>
+                  {user.followersCount > 0 && (
+                    <span className="text-xs text-slate-500">팔로워 {user.followersCount}</span>
+                  )}
+                </div>
+
+                <p className="text-sm text-slate-600 line-clamp-2">{user.bio}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/search/user/page.tsx
+++ b/src/app/search/user/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+type UserSearchResult = {
+  id: number;
+  nickname: string;
+  profileImgUrl: string | null;
+  bio: string;
+  followersCount: number;
+};
+
+export default function SearchUserPage() {
+  const params = useSearchParams();
+  const keyword = params.get('keyword') || '';
+  const [users, setUsers] = useState<UserSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      if (!keyword.trim()) return;
+
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${API_BASE_URL}/api/v1/users/search?keyword=${encodeURIComponent(keyword)}`,
+          {
+            method: 'GET',
+            credentials: 'include',
+          },
+        );
+
+        if (!res.ok) throw new Error('검색 실패');
+
+        const json = await res.json();
+        setUsers(json.data || []);
+      } catch (e) {
+        console.error(e);
+      }
+      setLoading(false);
+    }
+
+    load();
+  }, [keyword]);
+
+  return (
+    <div className="mt-4">
+      {loading ? (
+        <div className="text-center text-sm text-slate-500">불러오는 중...</div>
+      ) : users.length === 0 ? (
+        <div className="text-center text-sm text-slate-500">검색 결과가 없습니다.</div>
+      ) : (
+        <div className="space-y-1">
+          {users.map((user) => (
+            <a
+              key={user.id}
+              href={`/profile/${user.id}`}
+              className="flex items-center gap-4 p-4 rounded-md bg-white hover:bg-slate-50 transition"
+            >
+              {/* 프로필 이미지 */}
+              <img
+                src={user.profileImgUrl || '/tmpProfile.png'}
+                alt="profile"
+                className="w-14 h-14 rounded-full object-cover bg-slate-200"
+              />
+
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-slate-900">{user.nickname}</span>
+                  {user.followersCount > 0 && (
+                    <span className="text-xs text-slate-500">팔로워 {user.followersCount}</span>
+                  )}
+                </div>
+
+                <p className="text-sm text-slate-600 line-clamp-2">{user.bio}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/search/user/page.tsx
+++ b/src/app/search/user/page.tsx
@@ -1,86 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import UserSearchPageClient from './UserSearchPageClient';
 
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
-type UserSearchResult = {
-  id: number;
-  nickname: string;
-  profileImgUrl: string | null;
-  bio: string;
-  followersCount: number;
-};
-
-export default function SearchUserPage() {
-  const params = useSearchParams();
-  const keyword = params.get('keyword') || '';
-  const [users, setUsers] = useState<UserSearchResult[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    async function load() {
-      if (!keyword.trim()) return;
-
-      setLoading(true);
-      try {
-        const res = await fetch(
-          `${API_BASE_URL}/api/v1/users/search?keyword=${encodeURIComponent(keyword)}`,
-          {
-            method: 'GET',
-            credentials: 'include',
-          },
-        );
-
-        if (!res.ok) throw new Error('검색 실패');
-
-        const json = await res.json();
-        setUsers(json.data || []);
-      } catch (e) {
-        console.error(e);
-      }
-      setLoading(false);
-    }
-
-    load();
-  }, [keyword]);
-
+export default function Page() {
   return (
-    <div className="mt-4">
-      {loading ? (
-        <div className="text-center text-sm text-slate-500">불러오는 중...</div>
-      ) : users.length === 0 ? (
-        <div className="text-center text-sm text-slate-500">검색 결과가 없습니다.</div>
-      ) : (
-        <div className="space-y-1">
-          {users.map((user) => (
-            <a
-              key={user.id}
-              href={`/profile/${user.id}`}
-              className="flex items-center gap-4 p-4 rounded-md bg-white hover:bg-slate-50 transition"
-            >
-              {/* 프로필 이미지 */}
-              <img
-                src={user.profileImgUrl || '/tmpProfile.png'}
-                alt="profile"
-                className="w-14 h-14 rounded-full object-cover bg-slate-200"
-              />
-
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-bold text-slate-900">{user.nickname}</span>
-                  {user.followersCount > 0 && (
-                    <span className="text-xs text-slate-500">팔로워 {user.followersCount}</span>
-                  )}
-                </div>
-
-                <p className="text-sm text-slate-600 line-clamp-2">{user.bio}</p>
-              </div>
-            </a>
-          ))}
-        </div>
-      )}
-    </div>
+    <Suspense fallback={null}>
+      <UserSearchPageClient />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
#32 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
1. 사이드바 수정 (확대, 축소 버전)
2. 검색 패널 생성
3. 검색 -> 사용자탭 페이지 구현
4. 백엔드 (쇼로그 == 통합검색) 검색 api 다시 분리했습니다.
   * 키워드 입력 후 엔터 => 검색 api 호출됨(쇼로그 연관 X) => /search/shorlog 페이지로 이동
   * 검색탭의 쇼로그탭(/search/shorlog), 블로그탭(/search/blog) 에서 각각 검색 api 호출 후 페이지 구성 부탁드립니다....
   * 검색결과 정렬은 **임의**로 설정 해뒀습니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

[기본사이드바 - 더보기패널 - 검색패널]
<img width="1728" height="1219" alt="스크린샷 2025-11-30 오전 5 03 08" src="https://github.com/user-attachments/assets/f42096bb-a875-4e08-8b18-f24d12346992" />

[검색 엔터 치면 오게되는 /search/shorlog 페이지]
<img width="1523" height="817" alt="스크린샷 2025-11-30 오전 4 50 50" src="https://github.com/user-attachments/assets/8a9612e4-9029-40c6-a5ff-51af5bc20e60" />

[탭 이동으로 올 수 있는 /search/blog 페이지]
<img width="1601" height="928" alt="스크린샷 2025-11-30 오전 5 07 18" src="https://github.com/user-attachments/assets/d3afafad-ac9b-48cb-bcb1-5d7b8c091b91" />

[탭 이동으로 올 수 있는 /search/user 페이지]
<img width="1491" height="889" alt="스크린샷 2025-11-30 오전 4 50 43" src="https://github.com/user-attachments/assets/0ece7b1f-1042-4150-b624-59e5b0fe305b" />



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요