### PR TITLE
[Feat] 프로필 페이지 API 연결 완료

### DIFF
--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -1,0 +1,176 @@
+// src/features/profile/api/profileApis.ts
+
+import type { ShorlogItem } from '@/src/app/components/shorlog/feed/ShorlogFeedPageClient';
+import type { BlogSummary } from '@/src/types/blog';
+
+const API = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export type SortKey = 'latest' | 'popular' | 'oldest';
+
+export const apiSort = (k: SortKey) =>
+  k === 'latest' ? 'LATEST' : k === 'popular' ? 'POPULAR' : 'OLDEST';
+
+export async function getMyShorlogs(sort: SortKey): Promise<ShorlogItem[]> {
+  const res = await fetch(`${API}/api/v1/shorlog/my?sort=${sort}&page=0`, {
+    credentials: 'include',
+  });
+  const json = await res.json();
+
+  return (
+    json.data?.content?.map(
+      (i: any): ShorlogItem => ({
+        id: i.id,
+        thumbnailUrl: i.thumbnailUrl,
+        profileImgUrl: i.profileImgUrl,
+        nickname: i.nickname,
+        hashtags: i.hashtags ?? [],
+        likeCount: i.likeCount,
+        commentCount: i.commentCount,
+        firstLine: i.firstLine,
+      }),
+    ) ?? []
+  );
+}
+
+export async function getMyBlogs(sort: SortKey): Promise<BlogSummary[]> {
+  const res = await fetch(`${API}/api/v1/blogs/my?page=0&size=20&sortType=${apiSort(sort)}`, {
+    credentials: 'include',
+  });
+
+  const json = await res.json();
+  const items = json.content ?? [];
+
+  return items.map(
+    (i: any): BlogSummary => ({
+      id: i.id,
+      userId: i.userId,
+      userNickname: i.nickname,
+      profileImageUrl: i.profileImageUrl,
+      title: i.title,
+      contentPre: i.contentPre ?? i.content ?? '',
+      thumbnailUrl: i.thumbnailUrl,
+      hashtagNames: i.hashtagNames,
+      viewCount: i.viewCount,
+      likeCount: i.likeCount,
+      bookmarkCount: i.bookmarkCount,
+      commentCount: i.commentCount,
+      createdAt: i.createdAt,
+      modifiedAt: i.modifiedAt,
+      likedByMe: i.likedByMe,
+      bookmarkedByMe: i.bookmarkedByMe,
+    }),
+  );
+}
+
+export async function getBookmarkedShorlogs(sort: SortKey): Promise<ShorlogItem[]> {
+  const res = await fetch(`${API}/api/v1/shorlog/bookmark?sort=${sort}&page=0`, {
+    credentials: 'include',
+  });
+
+  const json = await res.json();
+
+  return (
+    json.data?.bookmarks?.map(
+      (i: any): ShorlogItem => ({
+        id: i.id,
+        thumbnailUrl: i.thumbnailUrl,
+        profileImgUrl: i.profileImgUrl,
+        nickname: i.nickname,
+        hashtags: i.hashtags ?? [],
+        likeCount: i.likeCount,
+        commentCount: i.commentCount,
+        firstLine: i.firstLine,
+      }),
+    ) ?? []
+  );
+}
+
+export async function getBookmarkedBlogs(sort: SortKey): Promise<BlogSummary[]> {
+  const res = await fetch(
+    `${API}/api/v1/blogs/bookmarks?page=0&size=20&sortType=${apiSort(sort)}`,
+    {
+      credentials: 'include',
+    },
+  );
+
+  const json = await res.json();
+  const items = json.content ?? [];
+
+  return items.map(
+    (i: any): BlogSummary => ({
+      id: i.id,
+      userId: i.userId,
+      userNickname: i.nickname,
+      profileImageUrl: i.profileImageUrl,
+      title: i.title,
+      contentPre: i.contentPre ?? i.content ?? '',
+      thumbnailUrl: i.thumbnailUrl,
+      hashtagNames: i.hashtagNames,
+      viewCount: i.viewCount,
+      likeCount: i.likeCount,
+      bookmarkCount: i.bookmarkCount,
+      commentCount: i.commentCount,
+      createdAt: i.createdAt,
+      modifiedAt: i.modifiedAt,
+      likedByMe: i.likedByMe,
+      bookmarkedByMe: i.bookmarkedByMe,
+    }),
+  );
+}
+
+export async function getUserShorlogs(userId: string, sort: SortKey): Promise<ShorlogItem[]> {
+  const res = await fetch(`${API}/api/v1/shorlog/user/${userId}?sort=${sort}&page=0`, {
+    credentials: 'include',
+  });
+
+  const json = await res.json();
+
+  return (
+    json.data?.content?.map(
+      (i: any): ShorlogItem => ({
+        id: i.id,
+        thumbnailUrl: i.thumbnailUrl,
+        profileImgUrl: i.profileImgUrl,
+        nickname: i.nickname,
+        hashtags: i.hashtags,
+        likeCount: i.likeCount,
+        commentCount: i.commentCount,
+        firstLine: i.firstLine,
+      }),
+    ) ?? []
+  );
+}
+
+export async function getUserBlogs(userId: string, sort: SortKey): Promise<BlogSummary[]> {
+  const res = await fetch(
+    `${API}/api/v1/users/${userId}/blogs?page=0&size=20&sortType=${apiSort(sort)}`,
+    {
+      credentials: 'include',
+    },
+  );
+
+  const json = await res.json();
+
+  const items = json.content ?? [];
+
+  return items.map(
+    (i: any): BlogSummary => ({
+      id: i.id,
+      userId: i.userId,
+      userNickname: i.nickname,
+      profileImageUrl: i.profileImageUrl,
+      title: i.title,
+      contentPre: i.contentPre ?? i.content ?? '',
+      thumbnailUrl: i.thumbnailUrl,
+      hashtagNames: i.hashtagNames,
+      viewCount: i.viewCount,
+      likeCount: i.likeCount,
+      bookmarkCount: i.bookmarkCount,
+      commentCount: i.commentCount,
+      createdAt: i.createdAt,
+      modifiedAt: i.modifiedAt,
+      likedByMe: i.likedByMe,
+      bookmarkedByMe: i.bookmarkedByMe,
+    }),
+  );
+}

--- a/src/app/components/profile/ProfileContent.tsx
+++ b/src/app/components/profile/ProfileContent.tsx
@@ -41,28 +41,31 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
 
       try {
         if (isMyPage) {
-          // 내 페이지
           if (primaryTab === 'mine') {
-            if (secondaryTab === 'short') {
-              setShorlogs(await getMyShorlogs(sortKey));
-            } else {
-              setBlogs(await getMyBlogs(sortKey));
-            }
+            const shortPromise = getMyShorlogs(sortKey);
+            const longPromise = getMyBlogs(sortKey);
+
+            const [shorts, longs] = await Promise.all([shortPromise, longPromise]);
+
+            setShorlogs(shorts);
+            setBlogs(longs);
           } else {
-            // 북마크
-            if (secondaryTab === 'short') {
-              setShorlogs(await getBookmarkedShorlogs(sortKey));
-            } else {
-              setBlogs(await getBookmarkedBlogs(sortKey));
-            }
+            const shortPromise = getBookmarkedShorlogs(sortKey);
+            const longPromise = getBookmarkedBlogs(sortKey);
+
+            const [shorts, longs] = await Promise.all([shortPromise, longPromise]);
+
+            setShorlogs(shorts);
+            setBlogs(longs);
           }
         } else {
-          // 다른 사람 페이지
-          if (secondaryTab === 'short') {
-            setShorlogs(await getUserShorlogs(userId, sortKey));
-          } else {
-            setBlogs(await getUserBlogs(userId, sortKey));
-          }
+          const shortPromise = getUserShorlogs(userId, sortKey);
+          const longPromise = getUserBlogs(userId, sortKey);
+
+          const [shorts, longs] = await Promise.all([shortPromise, longPromise]);
+
+          setShorlogs(shorts);
+          setBlogs(longs);
         }
       } finally {
         setLoading(false);
@@ -70,7 +73,7 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
     }
 
     load();
-  }, [userId, isMyPage, primaryTab, secondaryTab, sortKey]);
+  }, [userId, isMyPage, primaryTab, sortKey]);
 
   const shortCount = shorlogs.length;
   const longCount = blogs.length;

--- a/src/app/components/profile/ProfileContent.tsx
+++ b/src/app/components/profile/ProfileContent.tsx
@@ -176,7 +176,7 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
       {loading ? (
         <div className="mt-8 text-center text-sm text-slate-600">불러오는 중…</div>
       ) : secondaryTab === 'short' ? (
-        <ShorlogListView items={shorlogs} />
+        <ShorlogListView items={shorlogs} profileUserId={userId} />
       ) : (
         <BlogListView items={blogs} />
       )}

--- a/src/app/components/profile/ProfileContent.tsx
+++ b/src/app/components/profile/ProfileContent.tsx
@@ -12,6 +12,7 @@ import type { ShorlogItem } from '@/src/app/components/shorlog/feed/ShorlogFeedP
 import { useAuth } from '@/src/providers/AuthProvider';
 import type { BlogSummary } from '@/src/types/blog';
 import { useEffect, useState } from 'react';
+import { BlogListView, ShorlogListView, SortButtons } from './ProfileContentFeed';
 
 type SortKey = 'latest' | 'popular' | 'oldest';
 type PrimaryTab = 'mine' | 'bookmark';
@@ -74,10 +75,6 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
   const shortCount = shorlogs.length;
   const longCount = blogs.length;
 
-  /* =========================================================
-     5) 렌더링
-     ========================================================= */
-
   return (
     <section className="space-y-4">
       {/* 상단 탭 */}
@@ -107,7 +104,11 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
             </button>
           </div>
 
-          <SortButtons sortKey={sortKey} setSortKey={setSortKey} />
+          {primaryTab !== 'bookmark' && (
+            <div className="mb-1">
+              <SortButtons sortKey={sortKey} setSortKey={setSortKey} />
+            </div>
+          )}
         </div>
       ) : (
         <div className="flex items-end justify-between border-b border-slate-200">
@@ -135,7 +136,9 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
             </button>
           </div>
 
-          <SortButtons sortKey={sortKey} setSortKey={setSortKey} />
+          <div className="mb-1">
+            <SortButtons sortKey={sortKey} setSortKey={setSortKey} />
+          </div>
         </div>
       )}
 
@@ -176,167 +179,4 @@ export default function ProfileContent({ userId, isMyPage }: ProfileContentProps
       )}
     </section>
   );
-}
-
-/* =========================================================
-   6) 리스트 UI
-   ========================================================= */
-
-function ShorlogListView({ items }: { items: ShorlogItem[] }) {
-  if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">쇼로그가 없어요.</p>;
-
-  return (
-    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-      {items.map((item) => (
-        <ShorlogCardProfile key={item.id} item={item} />
-      ))}
-    </div>
-  );
-}
-
-function BlogListView({ items }: { items: BlogSummary[] }) {
-  if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">블로그가 없어요.</p>;
-
-  return (
-    <div className="space-y-4">
-      {items.map((item) => (
-        <BlogListItem key={item.id} item={item} />
-      ))}
-    </div>
-  );
-}
-
-/* =========================================================
-   7) 블로그 카드 (Figma 기반 UI)
-   ========================================================= */
-
-function BlogListItem({ item }: { item: BlogSummary }) {
-  return (
-    <a
-      href={`/blogs/${item.id}`}
-      className="block w-full rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 p-4 hover:shadow-md transition"
-    >
-      <div className="flex gap-4">
-        {item.thumbnailUrl ? (
-          <img
-            src={item.thumbnailUrl}
-            alt={item.title}
-            className="h-24 w-24 rounded-md object-cover"
-          />
-        ) : (
-          <div className="h-24 w-24 rounded-md bg-slate-200 flex items-center justify-center text-xs text-slate-500">
-            썸네일 없음
-          </div>
-        )}
-
-        <div className="flex-1 space-y-1">
-          <div className="flex items-center gap-2 text-xs text-slate-500">
-            <span>{item.userNickname}</span>
-            <span>•</span>
-            <span>{formatDate(item.createdAt)}</span>
-          </div>
-
-          <p className="text-base font-semibold text-slate-900 line-clamp-1">{item.title}</p>
-          <p className="text-sm text-slate-600 line-clamp-1">{item.contentPre}</p>
-
-          <div className="flex gap-1 flex-wrap mt-1">
-            {item.hashtagNames.map((tag) => (
-              <span
-                key={tag}
-                className="text-[11px] bg-slate-100 px-2 py-0.5 rounded-md text-slate-600"
-              >
-                #{tag}
-              </span>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-4 text-xs text-slate-500 mt-2">
-            <span>👁 {item.viewCount}</span>
-            <span>♡ {item.likeCount}</span>
-            <span>💬 {item.commentCount}</span>
-            <span>🔖 {item.bookmarkCount}</span>
-          </div>
-        </div>
-
-        <button className="self-start text-[12px] text-[#2979FF] font-medium whitespace-nowrap">
-          연결 쇼로그
-        </button>
-      </div>
-    </a>
-  );
-}
-
-/* =========================================================
-   8) 숏로그 카드 (프로필 버전)
-   ========================================================= */
-
-function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
-  return (
-    <a
-      href={`/shorlog/${item.id}`}
-      className="group flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 transition hover:-translate-y-1 hover:shadow-md"
-    >
-      <div className="aspect-[3/4] w-full overflow-hidden bg-slate-100">
-        <img
-          src={item.thumbnailUrl ?? '/images/default-thumbnail.jpg'}
-          className="h-full w-full object-cover group-hover:scale-105 transition"
-          alt={item.firstLine}
-        />
-      </div>
-
-      <div className="px-3 py-2">
-        <p className="text-sm font-medium text-slate-800 line-clamp-2">{item.firstLine}</p>
-        <div className="flex items-center justify-start gap-4 mt-2 text-xs text-slate-500">
-          <span>♡ {item.likeCount}</span>
-          <span>💬 {item.commentCount}</span>
-        </div>
-      </div>
-    </a>
-  );
-}
-
-/* =========================================================
-   9) 정렬 탭
-   ========================================================= */
-
-function SortButtons({
-  sortKey,
-  setSortKey,
-}: {
-  sortKey: SortKey;
-  setSortKey: (v: SortKey) => void;
-}) {
-  return (
-    <div className="inline-flex items-center rounded-md bg-slate-100 p-0.5 text-[13px]">
-      {[
-        { key: 'latest', label: '최신' },
-        { key: 'popular', label: '인기' },
-        { key: 'oldest', label: '오래된 순' },
-      ].map((item) => (
-        <button
-          key={item.key}
-          onClick={() => setSortKey(item.key as SortKey)}
-          className={`px-3 py-1.5 rounded-md ${
-            sortKey === item.key ? 'bg-white shadow text-slate-900' : 'text-slate-500'
-          }`}
-        >
-          {item.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-/* =========================================================
-   10) 상대 날짜 포맷
-   ========================================================= */
-
-function formatDate(dateStr: string) {
-  const date = new Date(dateStr);
-  const diff = (Date.now() - date.getTime()) / 1000;
-
-  if (diff < 60) return '방금 전';
-  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
-  return `${Math.floor(diff / 86400)}일 전`;
 }

--- a/src/app/components/profile/ProfileContentFeed.tsx
+++ b/src/app/components/profile/ProfileContentFeed.tsx
@@ -2,37 +2,13 @@
 
 import type { ShorlogItem } from '@/src/app/components/shorlog/feed/ShorlogFeedPageClient';
 import type { BlogSummary } from '@/src/types/blog';
-
-export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
-  return (
-    <a
-      href={`/shorlog/${item.id}`}
-      className="group flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 transition hover:-translate-y-1 hover:shadow-md"
-    >
-      <div className="aspect-[3/4] w-full overflow-hidden bg-slate-100">
-        <img
-          src={item.thumbnailUrl ?? '/images/default-thumbnail.jpg'}
-          className="h-full w-full object-cover group-hover:scale-105 transition"
-          alt={item.firstLine}
-        />
-      </div>
-
-      <div className="px-3 py-2">
-        <p className="text-sm font-medium text-slate-800 line-clamp-2">{item.firstLine}</p>
-        <div className="flex items-center justify-start gap-4 mt-2 text-xs text-slate-500">
-          <span>♡ {item.likeCount}</span>
-          <span>💬 {item.commentCount}</span>
-        </div>
-      </div>
-    </a>
-  );
-}
+import { Bookmark, Eye, Heart, MessageCircle } from 'lucide-react';
 
 export function ShorlogListView({ items }: { items: ShorlogItem[] }) {
   if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">쇼로그가 없어요.</p>;
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
       {items.map((item) => (
         <ShorlogCardProfile key={item.id} item={item} />
       ))}
@@ -40,53 +16,40 @@ export function ShorlogListView({ items }: { items: ShorlogItem[] }) {
   );
 }
 
-export function BlogListItem({ item }: { item: BlogSummary }) {
+export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
   return (
     <a
-      href={`/blogs/${item.id}`}
-      className="block w-full rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 p-4 hover:shadow-md transition"
+      href={`/shorlog/${item.id}`}
+      className="group flex flex-col overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-slate-100 hover:-translate-y-1 hover:shadow-md transition-all"
     >
-      <div className="flex gap-4">
+      {/* 이미지 영역: 3:4 비율 유지 */}
+      <div className="relative w-full overflow-hidden bg-slate-100 aspect-[3/4]">
         {item.thumbnailUrl ? (
           <img
             src={item.thumbnailUrl}
-            alt={item.title}
-            className="h-24 w-24 rounded-md object-cover"
+            alt={item.firstLine}
+            className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
         ) : (
-          <div className="h-24 w-24 rounded-md bg-slate-200 flex items-center justify-center text-xs text-slate-500">
-            썸네일 없음
-          </div>
+          <div className="absolute inset-0 bg-slate-200" />
         )}
 
-        <div className="flex-1 space-y-1">
-          <div className="flex items-center gap-2 text-xs text-slate-500">
-            <span>{item.userNickname}</span>
-            <span>•</span>
-            <span>{formatDate(item.createdAt)}</span>
-          </div>
-
-          <p className="text-base font-semibold text-slate-900 line-clamp-1">{item.title}</p>
-          <p className="text-sm text-slate-600 line-clamp-1">{item.contentPre}</p>
-
-          <div className="flex gap-1 flex-wrap mt-1">
-            {item.hashtagNames.map((tag) => (
-              <span
-                key={tag}
-                className="text-[11px] bg-slate-100 px-2 py-0.5 rounded-md text-slate-600"
-              >
-                #{tag}
-              </span>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-4 text-xs text-slate-500 mt-2">
-            <span>👁 {item.viewCount}</span>
-            <span>♡ {item.likeCount}</span>
-            <span>💬 {item.commentCount}</span>
-            <span>🔖 {item.bookmarkCount}</span>
+        {/* 오버레이 */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/25 via-black/10 to-transparent px-4 pb-3 pt-10 text-white text-[13px]">
+          <div className="flex items-center gap-4">
+            <span className="flex items-center gap-1">
+              <Heart className="h-4 w-4 text-white" /> {item.likeCount}
+            </span>
+            <span className="flex items-center gap-1">
+              <MessageCircle className="h-3.5 w-3.5 text-white" /> {item.commentCount}
+            </span>
           </div>
         </div>
+      </div>
+
+      {/* 텍스트 영역: 연한 회색 background */}
+      <div className="px-3 pb-3 pt-2 bg-slate-50 flex-1">
+        <p className="line-clamp-2 text-[13px] leading-snug text-slate-800">{item.firstLine}</p>
       </div>
     </a>
   );
@@ -101,6 +64,89 @@ export function BlogListView({ items }: { items: BlogSummary[] }) {
         <BlogListItem key={item.id} item={item} />
       ))}
     </div>
+  );
+}
+
+export function BlogListItem({ item }: { item: BlogSummary }) {
+  const hasThumbnail = !!item.thumbnailUrl;
+
+  return (
+    <a
+      href={`/blogs/${item.id}`}
+      className="block w-full rounded-lg bg-white shadow-sm ring-1 ring-slate-100 p-2 hover:-translate-y-0.5 hover:shadow-md transition"
+    >
+      <div className="flex gap-4 items-start">
+        {/* 썸네일 */}
+        <div className="flex-shrink-0">
+          {hasThumbnail ? (
+            <div className="relative h-24 w-24 overflow-hidden rounded-md bg-slate-100">
+              <img
+                src={item.thumbnailUrl!}
+                alt={item.title}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+          ) : (
+            <div className="flex h-24 w-24 items-center justify-center rounded-md bg-slate-200 text-[11px] text-slate-500">
+              썸네일 없음
+            </div>
+          )}
+        </div>
+
+        {/* 텍스트 */}
+        <div className="flex-1 space-y-3">
+          {/* 제목 + 날짜 (좌/우 배치) */}
+          <div className="flex items-center justify-between">
+            <h2 className="line-clamp-1 text-sm font-semibold text-slate-900 sm:text-base">
+              {item.title}
+            </h2>
+
+            <div className="flex items-center gap-2 text-[11px] text-slate-500 whitespace-nowrap mr-3">
+              <span className="h-1 w-1 rounded-full bg-slate-300" />
+              <span>{formatDate(item.createdAt)}</span>
+            </div>
+          </div>
+
+          {/* 요약 */}
+          <p className="line-clamp-1 text-xs text-slate-500 sm:text-sm">{item.contentPre}</p>
+
+          {/* 태그 */}
+          <div className="flex flex-wrap gap-1">
+            {item.hashtagNames.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-slate-50 px-2 py-0.5 text-[11px] text-slate-500"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+
+          {/* 통계 */}
+          <div className="flex items-center gap-4 text-[11px] text-slate-400">
+            <span className="flex items-center gap-1">
+              <Eye size={14} className="text-slate-400" />
+              {item.viewCount}
+            </span>
+
+            <span className="flex items-center gap-1">
+              <Heart size={14} className="text-slate-400" />
+              {item.likeCount}
+            </span>
+
+            <span className="flex items-center gap-1">
+              <MessageCircle size={14} className="text-slate-400" />
+              {item.commentCount}
+            </span>
+
+            <span className="flex items-center gap-1">
+              <Bookmark size={14} className="text-slate-400" />
+              {item.bookmarkCount}
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
   );
 }
 

--- a/src/app/components/profile/ProfileContentFeed.tsx
+++ b/src/app/components/profile/ProfileContentFeed.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import type { ShorlogItem } from '@/src/app/components/shorlog/feed/ShorlogFeedPageClient';
+import type { BlogSummary } from '@/src/types/blog';
+
+export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
+  return (
+    <a
+      href={`/shorlog/${item.id}`}
+      className="group flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 transition hover:-translate-y-1 hover:shadow-md"
+    >
+      <div className="aspect-[3/4] w-full overflow-hidden bg-slate-100">
+        <img
+          src={item.thumbnailUrl ?? '/images/default-thumbnail.jpg'}
+          className="h-full w-full object-cover group-hover:scale-105 transition"
+          alt={item.firstLine}
+        />
+      </div>
+
+      <div className="px-3 py-2">
+        <p className="text-sm font-medium text-slate-800 line-clamp-2">{item.firstLine}</p>
+        <div className="flex items-center justify-start gap-4 mt-2 text-xs text-slate-500">
+          <span>♡ {item.likeCount}</span>
+          <span>💬 {item.commentCount}</span>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export function ShorlogListView({ items }: { items: ShorlogItem[] }) {
+  if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">쇼로그가 없어요.</p>;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      {items.map((item) => (
+        <ShorlogCardProfile key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+export function BlogListItem({ item }: { item: BlogSummary }) {
+  return (
+    <a
+      href={`/blogs/${item.id}`}
+      className="block w-full rounded-2xl bg-white shadow-sm ring-1 ring-slate-100 p-4 hover:shadow-md transition"
+    >
+      <div className="flex gap-4">
+        {item.thumbnailUrl ? (
+          <img
+            src={item.thumbnailUrl}
+            alt={item.title}
+            className="h-24 w-24 rounded-md object-cover"
+          />
+        ) : (
+          <div className="h-24 w-24 rounded-md bg-slate-200 flex items-center justify-center text-xs text-slate-500">
+            썸네일 없음
+          </div>
+        )}
+
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2 text-xs text-slate-500">
+            <span>{item.userNickname}</span>
+            <span>•</span>
+            <span>{formatDate(item.createdAt)}</span>
+          </div>
+
+          <p className="text-base font-semibold text-slate-900 line-clamp-1">{item.title}</p>
+          <p className="text-sm text-slate-600 line-clamp-1">{item.contentPre}</p>
+
+          <div className="flex gap-1 flex-wrap mt-1">
+            {item.hashtagNames.map((tag) => (
+              <span
+                key={tag}
+                className="text-[11px] bg-slate-100 px-2 py-0.5 rounded-md text-slate-600"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-4 text-xs text-slate-500 mt-2">
+            <span>👁 {item.viewCount}</span>
+            <span>♡ {item.likeCount}</span>
+            <span>💬 {item.commentCount}</span>
+            <span>🔖 {item.bookmarkCount}</span>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export function BlogListView({ items }: { items: BlogSummary[] }) {
+  if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">블로그가 없어요.</p>;
+
+  return (
+    <div className="space-y-4">
+      {items.map((item) => (
+        <BlogListItem key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+export function SortButtons({
+  sortKey,
+  setSortKey,
+}: {
+  sortKey: 'latest' | 'popular' | 'oldest';
+  setSortKey: (v: 'latest' | 'popular' | 'oldest') => void;
+}) {
+  return (
+    <div className="inline-flex items-center rounded-md bg-slate-100 p-0.5 text-[13px]">
+      {[
+        { key: 'latest', label: '최신' },
+        { key: 'popular', label: '인기' },
+        { key: 'oldest', label: '오래된 순' },
+      ].map((item) => (
+        <button
+          key={item.key}
+          onClick={() => setSortKey(item.key as any)}
+          className={`px-3 py-1.5 rounded-md ${
+            sortKey === item.key ? 'bg-white shadow text-slate-900' : 'text-slate-500'
+          }`}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function formatDate(dateStr: string) {
+  const date = new Date(dateStr);
+  const diff = (Date.now() - date.getTime()) / 1000;
+
+  if (diff < 60) return '방금 전';
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  return `${Math.floor(diff / 86400)}일 전`;
+}

--- a/src/app/components/profile/ProfileContentFeed.tsx
+++ b/src/app/components/profile/ProfileContentFeed.tsx
@@ -48,7 +48,7 @@ export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
       </div>
 
       {/* 텍스트 영역: 연한 회색 background */}
-      <div className="px-3 pb-3 pt-2 bg-slate-50 flex-1">
+      <div className="px-2 py-1.5 bg-slate-50 flex-1">
         <p className="line-clamp-2 text-[13px] leading-snug text-slate-800">{item.firstLine}</p>
       </div>
     </a>

--- a/src/app/components/profile/ProfileContentFeed.tsx
+++ b/src/app/components/profile/ProfileContentFeed.tsx
@@ -3,23 +3,55 @@
 import type { ShorlogItem } from '@/src/app/components/shorlog/feed/ShorlogFeedPageClient';
 import type { BlogSummary } from '@/src/types/blog';
 import { Bookmark, Eye, Heart, MessageCircle } from 'lucide-react';
+import Link from 'next/link';
 
-export function ShorlogListView({ items }: { items: ShorlogItem[] }) {
+export function ShorlogListView({ items, profileUserId }: { items: ShorlogItem[]; profileUserId: string }) {
   if (items.length === 0) return <p className="mt-8 text-sm text-slate-600">쇼로그가 없어요.</p>;
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-      {items.map((item) => (
-        <ShorlogCardProfile key={item.id} item={item} />
+      {items.map((item, index) => (
+        <ShorlogCardProfile key={item.id} item={item} index={index} allItems={items} profileUserId={profileUserId} />
       ))}
     </div>
   );
 }
 
-export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
+export function ShorlogCardProfile({
+  item,
+  index,
+  allItems,
+  profileUserId
+}: {
+  item: ShorlogItem;
+  index: number;
+  allItems: ShorlogItem[];
+  profileUserId: string;
+}) {
+  const prevItem = index > 0 ? allItems[index - 1] : null;
+  const nextItem = index < allItems.length - 1 ? allItems[index + 1] : null;
+
+  const queryParams = new URLSearchParams();
+  if (prevItem) queryParams.set('prev', prevItem.id.toString());
+  if (nextItem) queryParams.set('next', nextItem.id.toString());
+  queryParams.set('profileId', profileUserId);
+
+  const href = `/shorlog/${item.id}?${queryParams.toString()}`;
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined') {
+      const feedIds = allItems.map(item => item.id);
+      sessionStorage.setItem('shorlog_feed_ids', JSON.stringify(feedIds));
+      sessionStorage.setItem('shorlog_current_index', index.toString());
+      sessionStorage.setItem('shorlog_source', 'profile');
+      sessionStorage.setItem('shorlog_profile_user_id', profileUserId);
+    }
+  };
+
   return (
-    <a
-      href={`/shorlog/${item.id}`}
+    <Link
+      href={href}
+      onClick={handleClick}
       className="group flex flex-col overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-slate-100 hover:-translate-y-1 hover:shadow-md transition-all"
     >
       {/* 이미지 영역: 3:4 비율 유지 */}
@@ -51,7 +83,7 @@ export function ShorlogCardProfile({ item }: { item: ShorlogItem }) {
       <div className="px-2 py-1.5 bg-slate-50 flex-1">
         <p className="line-clamp-2 text-[13px] leading-snug text-slate-800">{item.firstLine}</p>
       </div>
-    </a>
+    </Link>
   );
 }
 

--- a/src/app/components/profile/ProfileShorlogModal.tsx
+++ b/src/app/components/profile/ProfileShorlogModal.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+import ShorlogDetailPageClient from '../shorlog/detail/ShorlogDetailPageClient';
+import type { ShorlogDetail } from '../shorlog/detail/types';
+import type { ShorlogItem } from '../shorlog/feed/ShorlogFeedPageClient';
+
+interface Props {
+  shorlogId: number;
+  profileUserId: string;
+  allItems: ShorlogItem[];
+  currentIndex: number;
+  onClose: () => void;
+  onNavigate: (newId: number, newIndex: number) => void;
+}
+
+async function fetchShorlogDetail(id: number): Promise<ShorlogDetail> {
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+
+  const res = await fetch(`${API_BASE_URL}/api/v1/shorlog/${id}`, {
+    cache: 'no-store',
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error('숏로그를 찾을 수 없습니다.');
+    }
+    throw new Error('숏로그를 불러오는데 실패했습니다.');
+  }
+
+  const rsData = await res.json();
+  const data = rsData.data;
+
+  return {
+    id: data.id,
+    userId: data.userId,
+    username: data.username,
+    nickname: data.nickname,
+    profileImgUrl: data.profileImgUrl ?? null,
+    content: data.content,
+    thumbnailUrls: data.thumbnailUrls ?? [],
+    viewCount: data.viewCount ?? 0,
+    likeCount: data.likeCount ?? 0,
+    bookmarkCount: data.bookmarkCount ?? 0,
+    commentCount: data.commentCount ?? 0,
+    hashtags: data.hashtags ?? [],
+    createdAt: data.createdAt,
+    modifiedAt: data.modifiedAt,
+    linkedBlogId: data.linkedBlogId ?? null,
+  };
+}
+
+export default function ProfileShorlogModal({
+  shorlogId,
+  allItems,
+  currentIndex,
+  onClose,
+  onNavigate
+}: Omit<Props, 'profileUserId'>) {
+  const [detail, setDetail] = useState<ShorlogDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 이전/다음 항목 계산
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < allItems.length - 1;
+  const prevItem = hasPrev ? allItems[currentIndex - 1] : null;
+  const nextItem = hasNext ? allItems[currentIndex + 1] : null;
+
+  // 숏로그 상세 정보 로드
+  useEffect(() => {
+    async function loadDetail() {
+      try {
+        setLoading(true);
+        setError(null);
+        const shorlogDetail = await fetchShorlogDetail(shorlogId);
+        setDetail(shorlogDetail);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '숏로그를 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadDetail();
+  }, [shorlogId]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [onClose]);
+
+  // 네비게이션 핸들러
+  const handlePrev = () => {
+    if (hasPrev && prevItem) {
+      onNavigate(prevItem.id, currentIndex - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (hasNext && nextItem) {
+      onNavigate(nextItem.id, currentIndex + 1);
+    }
+  };
+
+  // 배경 클릭으로 닫기
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      onClick={handleOverlayClick}
+    >
+      {/* 배경 오버레이 */}
+      <div className="absolute inset-0 bg-black/55" />
+
+      {/* 이전/다음 화살표 */}
+      {hasPrev && (
+        <button
+          onClick={handlePrev}
+          className="absolute left-4 top-1/2 z-60 -translate-y-1/2 flex h-12 w-12 items-center justify-center rounded-full border-2 border-white bg-white text-2xl text-slate-700 shadow-xl transition hover:bg-slate-50 hover:scale-110"
+          aria-label="이전 숏로그"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </button>
+      )}
+
+      {hasNext && (
+        <button
+          onClick={handleNext}
+          className="absolute right-4 top-1/2 z-60 -translate-y-1/2 flex h-12 w-12 items-center justify-center rounded-full border-2 border-white bg-white text-2xl text-slate-700 shadow-xl transition hover:bg-slate-50 hover:scale-110"
+          aria-label="다음 숏로그"
+        >
+          <ChevronRight className="h-6 w-6" />
+        </button>
+      )}
+
+      {/* 닫기 버튼 */}
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 z-60 flex h-10 w-10 items-center justify-center rounded-full bg-black/50 text-white transition hover:bg-black/70"
+        aria-label="모달 닫기"
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      {/* 모달 컨텐츠 */}
+      <div
+        className="relative flex h-[90vh] w-full max-w-[1200px] px-4 py-4 md:px-6 md:py-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {loading ? (
+          <div className="flex h-full w-full items-center justify-center rounded-2xl bg-white">
+            <div className="text-center">
+              <div className="mb-4 h-8 w-8 animate-spin rounded-full border-2 border-sky-500 border-t-transparent mx-auto"></div>
+              <p className="text-slate-600">숏로그를 불러오는 중...</p>
+            </div>
+          </div>
+        ) : error ? (
+          <div className="flex h-full w-full items-center justify-center rounded-2xl bg-white">
+            <div className="text-center">
+              <p className="text-red-500 mb-4">{error}</p>
+              <button
+                onClick={onClose}
+                className="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        ) : detail ? (
+          <div className="w-full">
+            <ShorlogDetailPageClient
+              detail={detail}
+              isOwner={false} // TODO: 로그인 유저와 비교
+              hideNavArrows={true}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/profile/ProfileShorlogModalWrapper.tsx
+++ b/src/app/components/profile/ProfileShorlogModalWrapper.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function ProfileShorlogModalWrapper({ children }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const closeModal = () => {
+    // URL 쿼리에서 profileId 가져오기
+    let profileId = searchParams.get('profileId');
+
+    // pathname에서 프로필 ID 추출
+    if (!profileId) {
+      const match = pathname.match(/\/profile\/(\d+)/);
+      profileId = match ? match[1] : null;
+    }
+
+    // sessionStorage에서 가져오기
+    if (!profileId && typeof window !== 'undefined') {
+      profileId = sessionStorage.getItem('shorlog_profile_user_id');
+    }
+
+    if (profileId) {
+      // 새로고침 형태로 프로필 페이지 이동
+      window.location.href = `/profile/${profileId}`;
+    } else {
+      router.back();
+    }
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeModal();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
+  const handleOverlayClick = () => {
+    closeModal();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      data-scroll-locked="true"
+    >
+      <div
+        className="absolute inset-0 bg-black/55"
+        onClick={handleOverlayClick}
+      />
+
+      <div
+        className="relative flex h-[82vh] w-full max-w-[1200px] px-3 py-4 md:px-6 md:py-5 lg:px-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/components/shorlog/detail/ShorlogDetailPageClient.tsx
+++ b/src/app/components/shorlog/detail/ShorlogDetailPageClient.tsx
@@ -12,6 +12,7 @@ import type { ShorlogDetail } from './types';
 interface Props {
   detail: ShorlogDetail;
   isOwner?: boolean;
+  hideNavArrows?: boolean;
 }
 
 function HighlightedContent({ content, progress }: { content: string; progress: number }) {
@@ -84,7 +85,42 @@ function PrevNextNavArrows({ currentId }: { currentId: number }) {
   const hasNext = !!nextId;
 
   const handleNavigation = (targetId: string) => {
-    router.push(`/shorlog/${targetId}`);
+    // 프로필에서 온 경우 프로필 컨텍스트 유지
+    const profileId = searchParams.get('profileId');
+    const source = typeof window !== 'undefined' ? sessionStorage.getItem('shorlog_source') : null;
+
+    if (source === 'profile' && profileId) {
+      // 프로필에서 온 경우: profileId만 유지하고 prev/next는 새로 계산
+      const queryParams = new URLSearchParams();
+      queryParams.set('profileId', profileId);
+
+      // sessionStorage에서 피드 정보 가져와서 새로운 prev/next 계산
+      if (typeof window !== 'undefined') {
+        const feedIdsStr = sessionStorage.getItem('shorlog_feed_ids');
+        if (feedIdsStr) {
+          try {
+            const feedIds: number[] = JSON.parse(feedIdsStr);
+            const targetIndex = feedIds.findIndex(id => id === parseInt(targetId));
+
+            if (targetIndex !== -1) {
+              if (targetIndex > 0) {
+                queryParams.set('prev', feedIds[targetIndex - 1].toString());
+              }
+              if (targetIndex < feedIds.length - 1) {
+                queryParams.set('next', feedIds[targetIndex + 1].toString());
+              }
+            }
+          } catch {
+            // sessionStorage 파싱 실패 시 무시
+          }
+        }
+      }
+
+      router.push(`/shorlog/${targetId}?${queryParams.toString()}`);
+    } else {
+      // 피드에서 온 경우: 기존 방식
+      router.push(`/shorlog/${targetId}`);
+    }
   };
 
   return (
@@ -125,7 +161,7 @@ function PrevNextNavArrows({ currentId }: { currentId: number }) {
   );
 }
 
-export default function ShorlogDetailPageClient({ detail, isOwner = false }: Props) {
+export default function ShorlogDetailPageClient({ detail, isOwner = false, hideNavArrows = false }: Props) {
   const [ttsProgress, setTtsProgress] = useState(0);
   const firstLineForAlt = detail.content.split('\n')[0]?.slice(0, 40) ?? '';
 
@@ -144,7 +180,7 @@ export default function ShorlogDetailPageClient({ detail, isOwner = false }: Pro
 
   return (
     <div className="relative flex h-full w-full items-stretch">
-      <PrevNextNavArrows currentId={detail.id} />
+      {!hideNavArrows && <PrevNextNavArrows currentId={detail.id} />}
 
       <div className="flex h-full w-full overflow-hidden rounded-3xl bg-white shadow-xl ring-1 ring-slate-200">
         <div className="flex flex-1 items-stretch">

--- a/src/app/profile/[id]/@modal/(...)shorlog/[shorlogId]/page.tsx
+++ b/src/app/profile/[id]/@modal/(...)shorlog/[shorlogId]/page.tsx
@@ -1,0 +1,71 @@
+import ShorlogDetailPageClient from '@/src/app/components/shorlog/detail/ShorlogDetailPageClient';
+import ProfileShorlogModalWrapper from '@/src/app/components/profile/ProfileShorlogModalWrapper';
+import type { ShorlogDetail } from '@/src/app/components/shorlog/detail/types';
+import { getSessionUser } from '@/src/lib/getSessionUser';
+
+interface PageProps {
+  params: Promise<{
+    shorlogId: string; // 숏로그 ID
+  }>;
+  searchParams: Promise<{
+    profileId?: string;
+    prev?: string;
+    next?: string;
+  }>;
+}
+
+async function fetchShorlogDetail(id: string): Promise<ShorlogDetail> {
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+
+  const res = await fetch(`${API_BASE_URL}/api/v1/shorlog/${id}`, {
+    cache: 'no-store',
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error('숏로그를 찾을 수 없습니다.');
+    }
+    throw new Error('숏로그를 불러오는데 실패했습니다.');
+  }
+
+  const rsData = await res.json();
+  const data = rsData.data;
+
+  return {
+    id: data.id,
+    userId: data.userId,
+    username: data.username,
+    nickname: data.nickname,
+    profileImgUrl: data.profileImgUrl ?? null,
+    content: data.content,
+    thumbnailUrls: data.thumbnailUrls ?? [],
+    viewCount: data.viewCount ?? 0,
+    likeCount: data.likeCount ?? 0,
+    bookmarkCount: data.bookmarkCount ?? 0,
+    commentCount: data.commentCount ?? 0,
+    hashtags: data.hashtags ?? [],
+    createdAt: data.createdAt,
+    modifiedAt: data.modifiedAt,
+    linkedBlogId: data.linkedBlogId ?? null,
+  };
+}
+
+export default async function ProfileShorlogModalPage({ params }: PageProps) {
+  const { shorlogId } = await params;
+
+  // 병렬로 데이터 가져오기
+  const [detail, currentUser] = await Promise.all([
+    fetchShorlogDetail(shorlogId),
+    getSessionUser()
+  ]);
+
+  // 로그인한 유저와 숏로그 작성자 비교
+  const isOwner = currentUser ? currentUser.id === detail.userId : false;
+
+  return (
+    <ProfileShorlogModalWrapper>
+      <ShorlogDetailPageClient detail={detail} isOwner={isOwner} />
+    </ProfileShorlogModalWrapper>
+  );
+}

--- a/src/app/profile/[id]/@modal/default.tsx
+++ b/src/app/profile/[id]/@modal/default.tsx
@@ -1,0 +1,4 @@
+export default function Default() {
+  return null;
+}
+

--- a/src/app/profile/[id]/layout.tsx
+++ b/src/app/profile/[id]/layout.tsx
@@ -5,7 +5,7 @@ export default function ProfileLayout({
   modal
 }: {
   children: ReactNode;
-  modal?: ReactNode;
+  modal: ReactNode;
 }) {
   return (
     <>

--- a/src/app/profile/[id]/layout.tsx
+++ b/src/app/profile/[id]/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+export default function ProfileLayout({
+  children,
+  modal
+}: {
+  children: ReactNode;
+  modal?: ReactNode;
+}) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  );
+}
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
#37 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
1. 프로필 페이지 API 연결
   * 마이페이지 : 내 쇼로그 보기, 내 블로그 보기, 북마크한 쇼로그 보기, 북마크한 블로그 보기
   * 타인 프로필 페이지 : 작성한 쇼로그 보기, 작성한 블로그 보기
   * 북마크는 무조건 최신순 정렬 (정렬기준 추가 가능하긴 합니다만 북마크는 최신순만 있어도 될 듯 해 우선 유지할 생각입니다)
 
* 쇼로그 인기순 정렬은 백엔드 오류 해결 하면 정상작동 될 것으로 예상됩니다
* 프로필 페이지에서는 닉네임, 프로필사진 등이 없는게 나은 것 같아 쇼로그&블로그 모두 기존 컴포넌트 활용 안하고 별도 컴포넌트로 구성했습니다. 디자인이나 기능 등 수정하고 싶은 부분 있으시면 편하게 말씀해주시거나 코멘트 남겨주세요 (직접 수정도 환영입니다 🤗)

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요
<img width="1153" height="795" alt="스크린샷 2025-12-01 오전 12 56 14" src="https://github.com/user-attachments/assets/1737daac-14ef-43b1-b8fc-74474ed04348" />
<img width="1151" height="660" alt="스크린샷 2025-12-01 오전 12 56 20" src="https://github.com/user-attachments/assets/8b342acd-d331-4214-b547-fc008237da3f" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요