### PR TITLE
[Refactor] AI 채팅 '복사' 기능 추가, 섬네일 이미지 선택 반응형 적용

### DIFF
--- a/src/app/components/ImageSelector/ImageSelector.tsx
+++ b/src/app/components/ImageSelector/ImageSelector.tsx
@@ -291,8 +291,8 @@ export default function ImageSelector({
           {[
             { key: 'upload', label: '이미지 업로드' },
             { key: 'blog', label: '블로그 이미지' },
-            { key: 'unsplash', label: '무료 이미지 (Unsplash)' },
             { key: 'pixabay', label: '무료 이미지 (Pixabay)' },
+            { key: 'unsplash', label: '무료 이미지 (Unsplash)' },
           ].map((tab) => {
             const isActive = selectedTab === tab.key;
             return (

--- a/src/app/components/ImageSelector/ImageSelector.tsx
+++ b/src/app/components/ImageSelector/ImageSelector.tsx
@@ -242,44 +242,50 @@ export default function ImageSelector({
                 </p>
               </div>
 
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => {
-                    setCroppingImage(originalImage);
-                    setIsCropping(true);
-                  }}
-                  disabled={!selectedImage}
-                  className={`
-                    rounded-xl border px-3 py-1.5 text-xs transition flex items-center gap-1
-                    ${
-                      selectedImage
-                        ? 'border-slate-200 text-slate-600 hover:bg-slate-50'
-                        : 'border-slate-200 text-slate-400 bg-slate-50 cursor-not-allowed opacity-60'
-                    }
-                  `}
-                >
-                  <Crop className="w-4 h-4 mr-1" />
-                  자르기
-                </button>
-                <div className="group relative">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="inline-flex flex-nowrap items-center gap-2 max-[420px]:basis-full">
                   <button
-                    onClick={handleSubmit}
-                    disabled={!selectedImage || isSubmitting || isAlreadyThumbnailOriginal}
+                    onClick={() => {
+                      setCroppingImage(originalImage);
+                      setIsCropping(true);
+                    }}
+                    disabled={!selectedImage}
                     className={`
-                      rounded-xl px-3 py-1.5 text-xs text-white shadow-sm transition flex items-center gap-1
+                      rounded-xl border px-3 py-1.5 text-xs transition flex items-center gap-1
+                      whitespace-nowrap flex-shrink-0
                       ${
-                        selectedImage && !isSubmitting && !isAlreadyThumbnailOriginal
-                          ? 'bg-[#2979FF] hover:opacity-90'
-                          : 'bg-slate-300 cursor-not-allowed opacity-60'
+                        selectedImage
+                          ? 'border-slate-200 text-slate-600 hover:bg-slate-50'
+                          : 'border-slate-200 text-slate-400 bg-slate-50 cursor-not-allowed opacity-60'
                       }
                     `}
                   >
-                    <CheckCircle className="w-4 h-4 mr-1" />
-                    {isSubmitting ? '적용 중...' : '적용하기'}
+                    <Crop className="w-4 h-4 mr-1" />
+                    자르기
                   </button>
-                  {isAlreadyThumbnailOriginal && (
-                    <Tooltip text="이미 썸네일로 등록된 이미지입니다" />
-                  )}
+
+                  <div className="group relative">
+                    <button
+                      onClick={handleSubmit}
+                      disabled={!selectedImage || isSubmitting || isAlreadyThumbnailOriginal}
+                      className={`
+                        rounded-xl px-3 py-1.5 text-xs text-white shadow-sm transition flex items-center gap-1
+                        whitespace-nowrap flex-shrink-0
+                        ${
+                          selectedImage && !isSubmitting && !isAlreadyThumbnailOriginal
+                            ? 'bg-[#2979FF] hover:opacity-90'
+                            : 'bg-slate-300 cursor-not-allowed opacity-60'
+                        }
+                      `}
+                    >
+                      <CheckCircle className="w-4 h-4 mr-1" />
+                      {isSubmitting ? '적용 중...' : '적용하기'}
+                    </button>
+
+                    {isAlreadyThumbnailOriginal && (
+                      <Tooltip text="이미 썸네일로 등록된 이미지입니다" />
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
@@ -289,25 +295,28 @@ export default function ImageSelector({
         {/* 탭 메뉴 */}
         <div className="flex w-full items-center gap-1 rounded-full bg-slate-100 p-1 text-xs">
           {[
-            { key: 'upload', label: '이미지 업로드' },
-            { key: 'blog', label: '블로그 이미지' },
-            { key: 'pixabay', label: '무료 이미지 (Pixabay)' },
-            { key: 'unsplash', label: '무료 이미지 (Unsplash)' },
+            { key: 'upload', full: '이미지 업로드', short: '업로드' },
+            { key: 'blog', full: '블로그 이미지', short: '블로그' },
+            { key: 'pixabay', full: '무료 이미지 (Pixabay)', short: 'Pixabay' },
+            { key: 'unsplash', full: '무료 이미지 (Unsplash)', short: 'Unsplash' },
           ].map((tab) => {
             const isActive = selectedTab === tab.key;
+
             return (
               <button
                 key={tab.key}
                 type="button"
                 onClick={() => setSelectedTab(tab.key as ImageSelectorTabType)}
                 className={[
-                  'flex-1 rounded-full px-3 py-1.5 font-medium transition truncate',
+                  'flex-1 min-w-0 shrink rounded-full px-2 sm:px-3 py-1.5 font-medium transition',
+                  'whitespace-nowrap truncate',
                   isActive
                     ? 'bg-white text-slate-700 shadow-sm'
                     : 'text-slate-500 hover:text-slate-700',
                 ].join(' ')}
               >
-                {tab.label}
+                <span className="hidden sm:inline">{tab.full}</span>
+                <span className="sm:hidden">{tab.short}</span>
               </button>
             );
           })}

--- a/src/app/components/ImageSelector/tabs/UploadImageTab.tsx
+++ b/src/app/components/ImageSelector/tabs/UploadImageTab.tsx
@@ -160,7 +160,7 @@ export default function UploadTab({
         >
           <UploadCloud className="w-10 h-10 mb-3 text-slate-400" />
           <p className="text-xs text-slate-600">이미지를 끌어오거나 클릭하여 업로드하세요</p>
-          <p className="mt-1 text-[11px] text-slate-400 text-center">
+          <p className="mt-1 mx-2 text-[11px] text-slate-400 text-center">
             JPG / JPEG / PNG / WEBP 형식의 이미지 파일을 업로드할 수 있어요. (최대 10MB)
           </p>
         </div>
@@ -168,11 +168,14 @@ export default function UploadTab({
         // 파일이 있을 때: 카드형 정보 박스
         <div
           className={`
-            relative flex items-center gap-4 rounded-xl border bg-white/80 px-5 py-4
-            backdrop-blur-sm transition cursor-pointer hover:bg-slate-50/60 hover:shadow-sm
-            ${isDragging ? 'border-main bg-main/10 ring-2 ring-main/20' : ''}
-            ${isSelected ? 'border-main border-[2px] bg-white shadow-sm' : 'border-slate-200'}
-          `}
+    relative flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4
+    rounded-xl border bg-white/80
+    px-3 py-3 sm:px-5 sm:py-4
+    backdrop-blur-sm transition cursor-pointer
+    hover:bg-slate-50/60 hover:shadow-sm
+    ${isDragging ? 'border-main bg-main/10 ring-2 ring-main/20' : ''}
+    ${isSelected ? 'border-main border-[2px] bg-white shadow-sm' : 'border-slate-200'}
+  `}
           onClick={handleFileClick}
           onDrop={handleDrop}
           onDragOver={handleDragOver}
@@ -181,19 +184,18 @@ export default function UploadTab({
         >
           {/* 선택/삭제 아이콘 */}
           {isSelected ? (
-            <div className="absolute top-2.5 right-2.5 h-6 w-6 rounded-full bg-main flex items-center justify-center shadow-sm">
+            <div className="absolute top-2 right-2 h-6 w-6 rounded-full bg-main flex items-center justify-center shadow-sm">
               <Check className="w-4 h-4 text-white" />
             </div>
           ) : (
             <button
               onClick={handleRemoveFile}
               className="
-                absolute top-2.5 right-2.5
+                absolute top-2 right-2
                 inline-flex items-center justify-center
                 h-6 w-6 rounded-full
                 text-slate-400 hover:text-rose-500
-                hover:bg-rose-50    
-                transition
+                hover:bg-rose-50 transition
               "
               aria-label="파일 삭제"
               tabIndex={0}
@@ -203,25 +205,39 @@ export default function UploadTab({
           )}
 
           {/* 파일 아이콘 */}
-          <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-slate-50 border border-slate-100 flex-shrink-0">
-            <FileImage className="w-6 h-6 text-slate-400" />
+          <div
+            className="
+              flex items-center justify-center
+              w-10 h-10 sm:w-12 sm:h-12
+              rounded-lg bg-slate-50 border border-slate-100
+              flex-shrink-0
+            "
+          >
+            <FileImage className="w-5 h-5 sm:w-6 sm:h-6 text-slate-400" />
           </div>
 
           {/* 파일 정보 */}
-          <div className="flex-1 min-w-0 pr-6">
+          <div className="flex-1 min-w-0 pr-0 sm:pr-6 overflow-hidden">
             {uploadedFileUrl ? (
               <a
                 href={uploadedFileUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-slate-900 truncate underline hover:text-main transition"
                 onClick={(e) => e.stopPropagation()}
+                className="
+                  block w-full min-w-0
+                  text-xs text-slate-900 underline hover:text-main transition
+                  break-all sm:truncate
+                "
               >
                 {uploadedFile.name}
               </a>
             ) : (
-              <div className="text-xs text-slate-900 truncate">{uploadedFile.name}</div>
+              <div className="block w-full min-w-0 text-xs text-slate-900 break-all sm:truncate">
+                {uploadedFile.name}
+              </div>
             )}
+
             <div className="mt-0.5 text-[11px] text-slate-500">
               {(uploadedFile.size / 1024).toFixed(2)} KB
             </div>

--- a/src/app/components/ai/Tooltip.tsx
+++ b/src/app/components/ai/Tooltip.tsx
@@ -3,6 +3,8 @@ type TooltipAlign = 'left' | 'center' | 'right';
 
 type TooltipPosition = `${TooltipSide}-${TooltipAlign}`;
 
+type TooltipHover = 'group' | 'peer' | 'self' | 'none';
+
 interface TooltipProps {
   text: string;
   open?: boolean;
@@ -13,6 +15,8 @@ interface TooltipProps {
   className?: string;
   animationClass?: string;
   style?: React.CSSProperties;
+  hover?: TooltipHover;
+  hoverDelayMs?: number;
 }
 
 export default function Tooltip({
@@ -25,6 +29,8 @@ export default function Tooltip({
   className = 'bg-gray-700 text-white text-[12.5px] text-center font-light px-2 py-1 rounded-md border-none shadow',
   animationClass = '',
   style,
+  hover = 'group',
+  hoverDelayMs = 200,
 }: TooltipProps) {
   const [ps, pa] = position?.split('-') ?? [];
   const finalSide: TooltipSide =
@@ -57,11 +63,20 @@ export default function Tooltip({
 
   const finalPositionClass = positionClass ?? `${sideClass} ${alignClass}`;
 
+  const hoverVisibility =
+    hover === 'group'
+      ? `opacity-0 group-hover:opacity-100 group-hover:delay-[${hoverDelayMs}ms]`
+      : hover === 'peer'
+        ? `opacity-0 peer-hover:opacity-100 peer-hover:delay-[${hoverDelayMs}ms] peer-focus-visible:opacity-100`
+        : hover === 'self'
+          ? `opacity-0 hover:opacity-100 delay-[${hoverDelayMs}ms]`
+          : 'opacity-0'; // none
+
   const visibilityClass =
     open === undefined
-      ? `opacity-0 group-hover:opacity-100 group-hover:delay-200` // scale-95 group-hover:scale-100 추가 가능
+      ? hoverVisibility // scale-95 group-hover:scale-100 추가 가능
       : open
-        ? 'opacity-100 scale-100 delay-200'
+        ? `opacity-100 scale-100 delay-[${hoverDelayMs}ms]`
         : 'opacity-0 scale-90';
 
   const transitionClass =

--- a/src/app/components/ai/chat/AiChatHeader.tsx
+++ b/src/app/components/ai/chat/AiChatHeader.tsx
@@ -1,4 +1,4 @@
-import { Minus, PanelRight, SquareSquare } from 'lucide-react';
+import { Minus, PanelRight, PictureInPicture2 } from 'lucide-react';
 import Tooltip from '../Tooltip';
 
 interface AiChatHeaderProps {
@@ -18,7 +18,7 @@ export default function AiChatHeader({ mode, onToggleMode, onClose }: AiChatHead
             ariaLabel={mode === 'sidebar' ? '플로팅 모드로 전환' : '사이드바 모드로 전환'}
           >
             {mode === 'sidebar' ? (
-              <SquareSquare size={18} strokeWidth={1.75} />
+              <PictureInPicture2 size={18} strokeWidth={1.75} />
             ) : (
               <PanelRight size={18} strokeWidth={1.75} />
             )}

--- a/src/app/components/ai/chat/AiChatPanel.tsx
+++ b/src/app/components/ai/chat/AiChatPanel.tsx
@@ -177,7 +177,7 @@ export default function AiChatPanel({ title, content, children }: AiChatPanelPro
 
       {/* 열기 버튼 */}
       {!isOpen && (
-        <div className="fixed bottom-6 right-6 z-30 group">
+        <div className="fixed bottom-7 right-6 z-30 group">
           <ChatBotButton onClick={() => setIsOpen(true)} ariaLabel="AI 채팅 열기" />
           <Tooltip
             text="안녕하세요. TexTok 블로그 작성 도우미입니다."

--- a/src/app/components/ai/chat/ChatBubbleAction.tsx
+++ b/src/app/components/ai/chat/ChatBubbleAction.tsx
@@ -1,0 +1,56 @@
+import Tooltip from '@/src/app/components/ai/Tooltip';
+import { Check, Copy } from 'lucide-react';
+import { Dispatch, SetStateAction } from 'react';
+
+export interface ChatBubbleActionProps {
+  text: string;
+  index: number;
+  copiedIndex: number | null;
+  setCopiedIndex: Dispatch<SetStateAction<number | null>>;
+  align: 'left' | 'right';
+  alwaysShow?: boolean;
+}
+
+export default function ChatBubbleAction({
+  text,
+  index,
+  copiedIndex,
+  setCopiedIndex,
+  align,
+  alwaysShow,
+}: ChatBubbleActionProps) {
+  const positionClass = align === 'right' ? 'justify-end' : 'justify-start';
+  const copied = copiedIndex === index;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 1200);
+    } catch {
+      // 실패 시 무시
+    }
+  };
+
+  return (
+    <div className={`flex w-full ${positionClass} pt-2 min-h-[32px]`}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className={`
+            peer
+            w-7 h-7 flex items-center justify-center rounded-md bg-white text-slate-500
+            transition pointer-events-auto
+            hover:bg-slate-200 hover:text-slate-700
+            ${alwaysShow ? '' : 'opacity-0 group-hover:opacity-100'}
+          `}
+          aria-label="복사"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </button>
+        <Tooltip side="bottom" hover="peer" text={copied ? '복사됨' : '복사'} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -300,7 +300,7 @@ export default function PrivacyPage() {
               ]}
             />
             <p className="text-sm text-slate-600">
-              * TexTok은 위탁업체가 개인정보를 안전하게 처리하도록 관리·감독하며, 관련 법령이
+              * 서비스는 위탁업체가 개인정보를 안전하게 처리하도록 관리·감독하며, 관련 법령이
               요구하는 보호조치를 이행합니다.
             </p>
           </Section>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- AI 채팅에 '복사' 기능 추가
- 블로그 작성 페이지에서 '섬네일 이미지 선택'이 반응형으로 안 되있어서 적용

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

- 블로그 작성 페이지 반응형
  <img width="300" alt="스크린샷 2025-12-10 205243" src="https://github.com/user-attachments/assets/e8d93729-9b4c-4ced-8ac7-fc058b3bd2de" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요